### PR TITLE
[Homebase/Recruit] Add randomize name logic

### DIFF
--- a/Scenes/UI/Homebase/Character Name Input Screen.tscn
+++ b/Scenes/UI/Homebase/Character Name Input Screen.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://Scripts/UI/Homebase/CharacterNameInputScreen.gd" id="1_wq8uj"]
 
-[node name="Character Name Input Screen" type="Control" node_paths=PackedStringArray("name_entry")]
+[node name="Character Name Input Screen" type="Control" node_paths=PackedStringArray("randomize_name_button", "name_entry")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -11,6 +11,18 @@ grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
 script = ExtResource("1_wq8uj")
+names_list = "Nyx
+Spock
+Natalya
+Gael
+Kirk
+Flynn
+Uhura
+Sulu
+Scotty
+Chekov
+Leonard"
+randomize_name_button = NodePath("VBoxContainer/Randomize Name Button")
 name_entry = NodePath("VBoxContainer/LineEdit")
 
 [node name="Background" type="Panel" parent="."]

--- a/Scripts/UI/Homebase/CharacterNameInputScreen.gd
+++ b/Scripts/UI/Homebase/CharacterNameInputScreen.gd
@@ -5,6 +5,9 @@ class_name CharacterNameInputScreen extends Control
 ## Fired when the player finishes entering a name for the player.
 signal player_finished_entering_name()
 
+@export_multiline var names_list
+@export var randomize_name_button: BaseButton = null
+
 ## The node storing the entered name.
 @export var name_entry: LineEdit
 
@@ -13,6 +16,7 @@ var current_character: PlayerCombatant
 
 func _ready() -> void:
 	name_entry.text_submitted.connect( on_text_submitted )
+	randomize_name_button.button_down.connect( on_randomize_name_button_pressed )
 	
 func start_accepting_input(new_character: PlayerCombatant) -> void:
 	current_character = new_character
@@ -31,3 +35,8 @@ func on_text_submitted(new_text: String) -> void:
 	if OS.is_debug_build() == true:
 		print("CharacterNameInput :: The new character's name is %s and their class is: %s." % [current_character.char_name, current_character.pc_class.localization_name])
 	player_finished_entering_name.emit()
+
+func on_randomize_name_button_pressed() -> void:
+	var names = names_list.split('\n')
+	var random_index = randi_range(0, len(names) - 1)
+	name_entry.text = names[random_index]


### PR DESCRIPTION

## Changes
`Character Name Input Screen.tscn` has a Randomize Name button, which currently has no logic connected to it. This PR adds that logic by exporting the names list to choose from and connecting the button.

![image](https://github.com/EveningComet/Project-Horizon/assets/33893929/92b5fd71-d762-4238-b353-15ee285b5275)
![image](https://github.com/EveningComet/Project-Horizon/assets/33893929/acddf4e7-c535-4474-86e9-8cc94bddeb80)
