### PR TITLE
[Skills Menu] Introduce skills menu

### DIFF
--- a/Game Data/Player Character Classes/Class Skills/Aegis Skills/Aegis Pulse Beam.tres
+++ b/Game Data/Player Character Classes/Class Skills/Aegis Skills/Aegis Pulse Beam.tres
@@ -1,12 +1,14 @@
-[gd_resource type="Resource" script_class="SkillData" load_steps=3 format=3 uid="uid://cydkltv3usq2l"]
+[gd_resource type="Resource" script_class="SkillData" load_steps=4 format=3 uid="uid://cydkltv3usq2l"]
 
 [ext_resource type="Resource" uid="uid://dpm37e6oshty" path="res://Game Data/Player Character Classes/Class Skills/Aegis Skills/Aegis Pulse Beam DDE.tres" id="1_50sg2"]
 [ext_resource type="Script" path="res://Scripts/Character/Skill/SkillData.gd" id="1_m3w6m"]
+[ext_resource type="Texture2D" uid="uid://d3rnajtkaw8ms" path="res://Imported Assets/UI/Wenrexa UI Kit #4/Icons/Icon37.png" id="1_mjon2"]
 
 [resource]
 script = ExtResource("1_m3w6m")
 localization_name = "Pulse Beam"
 localization_description = "Fire a laser beam at an enemy. It will hit twice."
+cost = 5
 is_passive = false
 action_type = 0
 num_activations = 2
@@ -18,3 +20,4 @@ success_chance = 1.0
 unlockable = Array[ExtResource("1_m3w6m")]([])
 is_ranged = false
 effects = Array[Resource("res://Scripts/Character/Skill/Skill Effects/SkillEffect.gd")]([ExtResource("1_50sg2")])
+display_texture = ExtResource("1_mjon2")

--- a/Game Data/Player Character Classes/Class Skills/Aegis Skills/Aegis Shell.tres
+++ b/Game Data/Player Character Classes/Class Skills/Aegis Skills/Aegis Shell.tres
@@ -1,6 +1,7 @@
-[gd_resource type="Resource" script_class="SkillData" load_steps=3 format=3 uid="uid://c0h3wsdqfllab"]
+[gd_resource type="Resource" script_class="SkillData" load_steps=4 format=3 uid="uid://c0h3wsdqfllab"]
 
 [ext_resource type="Resource" uid="uid://b7tnwb1sfl1wo" path="res://Game Data/Player Character Classes/Class Skills/Aegis Skills/Aegis Shell DD.tres" id="1_3ul5r"]
+[ext_resource type="Texture2D" uid="uid://5o3im77uglyl" path="res://Imported Assets/UI/Wenrexa UI Kit #4/Icons/Icon36.png" id="1_8vow5"]
 [ext_resource type="Script" path="res://Scripts/Character/Skill/SkillData.gd" id="1_koweo"]
 
 [resource]
@@ -19,3 +20,4 @@ success_chance = 1.0
 unlockable = Array[ExtResource("1_koweo")]([])
 is_ranged = false
 effects = Array[Resource("res://Scripts/Character/Skill/Skill Effects/SkillEffect.gd")]([ExtResource("1_3ul5r")])
+display_texture = ExtResource("1_8vow5")

--- a/Game Data/Player Character Classes/Class Skills/Seeker Skills/Seeker Field Medicine.tres
+++ b/Game Data/Player Character Classes/Class Skills/Seeker Skills/Seeker Field Medicine.tres
@@ -1,7 +1,8 @@
-[gd_resource type="Resource" script_class="SkillData" load_steps=3 format=3 uid="uid://by8cb3jap5hqh"]
+[gd_resource type="Resource" script_class="SkillData" load_steps=4 format=3 uid="uid://by8cb3jap5hqh"]
 
 [ext_resource type="Resource" uid="uid://b4r02cq3s3xe1" path="res://Game Data/Player Character Classes/Class Skills/Seeker Skills/Seeker Field Medicine DH.tres" id="1_b6opl"]
 [ext_resource type="Script" path="res://Scripts/Character/Skill/SkillData.gd" id="1_g62jx"]
+[ext_resource type="Texture2D" uid="uid://bfn1k6ty5eivc" path="res://Imported Assets/UI/Wenrexa UI Kit #4/Icons/Icon38.png" id="1_ib0pv"]
 
 [resource]
 script = ExtResource("1_g62jx")
@@ -19,3 +20,4 @@ success_chance = 1.0
 unlockable = Array[ExtResource("1_g62jx")]([])
 is_ranged = false
 effects = Array[Resource("res://Scripts/Character/Skill/Skill Effects/SkillEffect.gd")]([ExtResource("1_b6opl")])
+display_texture = ExtResource("1_ib0pv")

--- a/Scenes/UI/Homebase/Homebase Home Menu.tscn
+++ b/Scenes/UI/Homebase/Homebase Home Menu.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=2 format=3 uid="uid://dk5bafb02fsas"]
+[gd_scene load_steps=3 format=3 uid="uid://dk5bafb02fsas"]
 
 [ext_resource type="Script" path="res://Scripts/UI/Homebase/HomebaseHome.gd" id="1_ordyh"]
+[ext_resource type="PackedScene" uid="uid://dks4qxa6s4ful" path="res://Scenes/UI/Skill/Skill Menu.tscn" id="2_vvfrj"]
 
 [node name="Homebase Home Menu" type="CanvasLayer"]
 
-[node name="HomebaseHome" type="Control" parent="." node_paths=PackedStringArray("missions_button", "manage_characters_button", "acquisition_button", "quit_button")]
+[node name="HomebaseHome" type="Control" parent="." node_paths=PackedStringArray("missions_button", "manage_characters_button", "acquisition_button", "quit_button", "skill_menu")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -19,6 +20,7 @@ missions_button = NodePath("VBoxContainer/Mission")
 manage_characters_button = NodePath("VBoxContainer/Manage Characters")
 acquisition_button = NodePath("VBoxContainer/Acquisitions")
 quit_button = NodePath("VBoxContainer/Quit")
+skill_menu = NodePath("SkillMenu")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="HomebaseHome"]
 custom_minimum_size = Vector2(50, 50)
@@ -55,3 +57,5 @@ custom_minimum_size = Vector2(200, 50)
 layout_mode = 2
 focus_neighbor_bottom = NodePath("../Mission")
 text = "Quit"
+
+[node name="SkillMenu" parent="HomebaseHome" instance=ExtResource("2_vvfrj")]

--- a/Scenes/UI/Skill/Skill Menu Button.tscn
+++ b/Scenes/UI/Skill/Skill Menu Button.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=3 format=3 uid="uid://bngujmgvwnby5"]
+
+[ext_resource type="Script" path="res://Scripts/UI/Skill/SkillMenuButton.gd" id="1_1siys"]
+[ext_resource type="Texture2D" uid="uid://5o3im77uglyl" path="res://Imported Assets/UI/Wenrexa UI Kit #4/Icons/Icon36.png" id="1_478kh"]
+
+[node name="SkillMenuButton" type="TextureButton"]
+texture_normal = ExtResource("1_478kh")
+script = ExtResource("1_1siys")

--- a/Scenes/UI/Skill/Skill Menu Button.tscn
+++ b/Scenes/UI/Skill/Skill Menu Button.tscn
@@ -3,6 +3,18 @@
 [ext_resource type="Script" path="res://Scripts/UI/Skill/SkillMenuButton.gd" id="1_1siys"]
 [ext_resource type="Texture2D" uid="uid://5o3im77uglyl" path="res://Imported Assets/UI/Wenrexa UI Kit #4/Icons/Icon36.png" id="1_478kh"]
 
-[node name="SkillMenuButton" type="TextureButton"]
+[node name="SkillMenuButton" type="TextureButton" node_paths=PackedStringArray("level_label")]
+custom_minimum_size = Vector2(110, 0)
+offset_right = 88.0
+offset_bottom = 88.0
 texture_normal = ExtResource("1_478kh")
 script = ExtResource("1_1siys")
+level_label = NodePath("LevelLabel")
+
+[node name="LevelLabel" type="Label" parent="."]
+layout_mode = 0
+offset_left = 64.0
+offset_top = 64.0
+offset_right = 104.0
+offset_bottom = 87.0
+text = "n/nn"

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=4 format=3 uid="uid://dks4qxa6s4ful"]
+[gd_scene load_steps=3 format=3 uid="uid://dks4qxa6s4ful"]
 
 [ext_resource type="Script" path="res://Scripts/UI/Skill/SkillMenu.gd" id="1_gb7ft"]
-[ext_resource type="Texture2D" uid="uid://dj3erae32tw7x" path="res://Imported Assets/UI/Wenrexa UI Kit #4/Icons/Icon23.png" id="2_wplbt"]
-[ext_resource type="Script" path="res://Scripts/UI/Skill/SkillMenuButton.gd" id="3_ab0j6"]
+[ext_resource type="PackedScene" uid="uid://bngujmgvwnby5" path="res://Scenes/UI/Skill/Skill Menu Button.tscn" id="2_44m12"]
 
 [node name="SkillMenu" type="CanvasLayer"]
 
@@ -18,6 +17,7 @@ tab_bar = NodePath("TabBar")
 exit_button = NodePath("ExitButton")
 skill_container = NodePath("SkillPanel/HBoxContainer")
 skill_description_label = NodePath("SkillPanel/SkillDescriptionPanel/SkillDescriptionLabel")
+skill_menu_button_template = ExtResource("2_44m12")
 
 [node name="TabBar" type="TabBar" parent="SkillMenu"]
 layout_mode = 0
@@ -42,10 +42,8 @@ offset_top = 24.0
 offset_right = 452.0
 offset_bottom = 124.0
 
-[node name="SkillMenuButton" type="TextureButton" parent="SkillMenu/SkillPanel/HBoxContainer"]
+[node name="SkillMenuButton" parent="SkillMenu/SkillPanel/HBoxContainer" instance=ExtResource("2_44m12")]
 layout_mode = 2
-texture_normal = ExtResource("2_wplbt")
-script = ExtResource("3_ab0j6")
 
 [node name="SkillDescriptionPanel" type="Panel" parent="SkillMenu/SkillPanel"]
 custom_minimum_size = Vector2(300, 500)

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -45,8 +45,9 @@ offset_top = 37.0
 offset_right = 132.0
 offset_bottom = 137.0
 
-[node name="SkillMenuButton" parent="SkillMenu/SkillPanel/HBoxContainer" instance=ExtResource("2_44m12")]
+[node name="PartyEmptyLabel" type="Label" parent="SkillMenu/SkillPanel/HBoxContainer"]
 layout_mode = 2
+text = "No members recruited"
 
 [node name="SkillPointsLabel" type="Label" parent="SkillMenu/SkillPanel"]
 layout_mode = 0
@@ -54,7 +55,7 @@ offset_left = 25.0
 offset_top = 723.0
 offset_right = 212.0
 offset_bottom = 746.0
-text = "Available skill points: nn"
+text = "No available skills point"
 
 [node name="ConfirmButton" type="Button" parent="SkillMenu/SkillPanel"]
 custom_minimum_size = Vector2(200, 50)
@@ -62,6 +63,7 @@ offset_left = 233.0
 offset_top = 707.0
 offset_right = 433.0
 offset_bottom = 757.0
+disabled = true
 text = "Confirm"
 
 [node name="UndoSkillPointsButton" type="Button" parent="SkillMenu/SkillPanel"]
@@ -71,6 +73,7 @@ offset_left = 433.0
 offset_top = 707.0
 offset_right = 633.0
 offset_bottom = 757.0
+disabled = true
 text = "Undo points"
 
 [node name="ExitButton" type="Button" parent="SkillMenu"]

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -5,7 +5,7 @@
 
 [node name="SkillMenu" type="CanvasLayer"]
 
-[node name="SkillMenu" type="Control" parent="." node_paths=PackedStringArray("tab_bar", "exit_button", "skill_container", "skill_description_label")]
+[node name="SkillMenu" type="Control" parent="." node_paths=PackedStringArray("tab_bar", "exit_button", "undo_skill_points_button", "skill_container", "skill_points_label")]
 layout_mode = 3
 anchors_preset = 0
 offset_left = 399.0
@@ -15,8 +15,9 @@ offset_bottom = 253.0
 script = ExtResource("1_gb7ft")
 tab_bar = NodePath("TabBar")
 exit_button = NodePath("ExitButton")
+undo_skill_points_button = NodePath("SkillPanel/UndoSkillPointsLabel")
 skill_container = NodePath("SkillPanel/HBoxContainer")
-skill_description_label = NodePath("SkillPanel/SkillDescriptionPanel/SkillDescriptionLabel")
+skill_points_label = NodePath("SkillPanel/SkillPointsLabel")
 skill_menu_button_template = ExtResource("2_44m12")
 
 [node name="TabBar" type="TabBar" parent="SkillMenu"]
@@ -36,33 +37,31 @@ offset_right = 40.0
 offset_bottom = 80.0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="SkillMenu/SkillPanel"]
-layout_mode = 0
-offset_left = 352.0
-offset_top = 24.0
-offset_right = 452.0
-offset_bottom = 124.0
+layout_mode = 1
+offset_left = 32.0
+offset_top = 37.0
+offset_right = 132.0
+offset_bottom = 137.0
 
 [node name="SkillMenuButton" parent="SkillMenu/SkillPanel/HBoxContainer" instance=ExtResource("2_44m12")]
 layout_mode = 2
 
-[node name="SkillDescriptionPanel" type="Panel" parent="SkillMenu/SkillPanel"]
-custom_minimum_size = Vector2(300, 500)
+[node name="UndoSkillPointsLabel" type="Button" parent="SkillMenu/SkillPanel"]
+custom_minimum_size = Vector2(200, 50)
 layout_mode = 0
-offset_left = 32.0
-offset_top = 24.0
-offset_right = 182.0
-offset_bottom = 99.0
+offset_left = 225.0
+offset_top = 707.0
+offset_right = 425.0
+offset_bottom = 757.0
+text = "Undo points"
 
-[node name="SkillDescriptionLabel" type="RichTextLabel" parent="SkillMenu/SkillPanel/SkillDescriptionPanel"]
-layout_mode = 2
-offset_left = 24.0
-offset_top = 20.0
-offset_right = 274.0
-offset_bottom = 320.0
-bbcode_enabled = true
-text = "[b]Skills name[/b]
-Skill description
-Later maybe add a portrait in this panel, where we will overlay the skill description on top"
+[node name="SkillPointsLabel" type="Label" parent="SkillMenu/SkillPanel"]
+layout_mode = 0
+offset_left = 25.0
+offset_top = 723.0
+offset_right = 177.0
+offset_bottom = 746.0
+text = "Available skill points: nn"
 
 [node name="ExitButton" type="Button" parent="SkillMenu"]
 custom_minimum_size = Vector2(50, 0)

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -5,7 +5,7 @@
 
 [node name="SkillMenu" type="CanvasLayer"]
 
-[node name="SkillMenu" type="Control" parent="." node_paths=PackedStringArray("tab_bar", "exit_button", "undo_skill_points_button", "skill_container", "skill_points_label")]
+[node name="SkillMenu" type="Control" parent="." node_paths=PackedStringArray("tab_bar", "exit_button", "confirm_button", "undo_skill_points_button", "skill_container", "skill_points_label")]
 layout_mode = 3
 anchors_preset = 0
 offset_left = 399.0
@@ -15,7 +15,8 @@ offset_bottom = 253.0
 script = ExtResource("1_gb7ft")
 tab_bar = NodePath("TabBar")
 exit_button = NodePath("ExitButton")
-undo_skill_points_button = NodePath("SkillPanel/UndoSkillPointsLabel")
+confirm_button = NodePath("SkillPanel/ConfirmButton")
+undo_skill_points_button = NodePath("SkillPanel/UndoSkillPointsButton")
 skill_container = NodePath("SkillPanel/HBoxContainer")
 skill_points_label = NodePath("SkillPanel/SkillPointsLabel")
 skill_menu_button_template = ExtResource("2_44m12")
@@ -46,22 +47,30 @@ offset_bottom = 137.0
 [node name="SkillMenuButton" parent="SkillMenu/SkillPanel/HBoxContainer" instance=ExtResource("2_44m12")]
 layout_mode = 2
 
-[node name="UndoSkillPointsLabel" type="Button" parent="SkillMenu/SkillPanel"]
-custom_minimum_size = Vector2(200, 50)
-layout_mode = 0
-offset_left = 225.0
-offset_top = 707.0
-offset_right = 425.0
-offset_bottom = 757.0
-text = "Undo points"
-
 [node name="SkillPointsLabel" type="Label" parent="SkillMenu/SkillPanel"]
 layout_mode = 0
 offset_left = 25.0
 offset_top = 723.0
-offset_right = 177.0
+offset_right = 212.0
 offset_bottom = 746.0
 text = "Available skill points: nn"
+
+[node name="ConfirmButton" type="Button" parent="SkillMenu/SkillPanel"]
+custom_minimum_size = Vector2(200, 50)
+offset_left = 233.0
+offset_top = 707.0
+offset_right = 433.0
+offset_bottom = 757.0
+text = "Confirm"
+
+[node name="UndoSkillPointsButton" type="Button" parent="SkillMenu/SkillPanel"]
+custom_minimum_size = Vector2(200, 50)
+layout_mode = 0
+offset_left = 433.0
+offset_top = 707.0
+offset_right = 633.0
+offset_bottom = 757.0
+text = "Undo points"
 
 [node name="ExitButton" type="Button" parent="SkillMenu"]
 custom_minimum_size = Vector2(50, 0)

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -5,7 +5,7 @@
 
 [node name="SkillMenu" type="CanvasLayer"]
 
-[node name="SkillMenu" type="Control" parent="." node_paths=PackedStringArray("tab_bar", "exit_button", "confirm_button", "undo_skill_points_button", "skill_container", "skill_points_label")]
+[node name="SkillMenu" type="Control" parent="." node_paths=PackedStringArray("tab_bar", "exit_button", "confirm_button", "undo_skill_points_button", "skill_container", "skill_points_label", "canvas")]
 layout_mode = 3
 anchors_preset = 0
 offset_left = 399.0
@@ -20,6 +20,7 @@ undo_skill_points_button = NodePath("SkillPanel/UndoSkillPointsButton")
 skill_container = NodePath("SkillPanel/HBoxContainer")
 skill_points_label = NodePath("SkillPanel/SkillPointsLabel")
 skill_menu_button_template = ExtResource("2_44m12")
+canvas = NodePath("..")
 
 [node name="TabBar" type="TabBar" parent="SkillMenu"]
 layout_mode = 0

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -1,18 +1,76 @@
-[gd_scene load_steps=2 format=3 uid="uid://dks4qxa6s4ful"]
+[gd_scene load_steps=4 format=3 uid="uid://dks4qxa6s4ful"]
 
 [ext_resource type="Script" path="res://Scripts/UI/Skill/SkillMenu.gd" id="1_gb7ft"]
+[ext_resource type="Texture2D" uid="uid://dj3erae32tw7x" path="res://Imported Assets/UI/Wenrexa UI Kit #4/Icons/Icon23.png" id="2_wplbt"]
+[ext_resource type="Script" path="res://Scripts/UI/Skill/SkillMenuButton.gd" id="3_ab0j6"]
 
 [node name="SkillMenu" type="CanvasLayer"]
 
-[node name="SkillMenu" type="Control" parent="."]
+[node name="SkillMenu" type="Control" parent="." node_paths=PackedStringArray("tab_bar", "exit_button", "skill_container", "skill_description_label")]
 layout_mode = 3
 anchors_preset = 0
-offset_right = 40.0
-offset_bottom = 40.0
+offset_left = 399.0
+offset_top = 213.0
+offset_right = 439.0
+offset_bottom = 253.0
 script = ExtResource("1_gb7ft")
+tab_bar = NodePath("TabBar")
+exit_button = NodePath("ExitButton")
+skill_container = NodePath("SkillPanel/HBoxContainer")
+skill_description_label = NodePath("SkillPanel/SkillDescriptionPanel/SkillDescriptionLabel")
 
-[node name="Panel" type="Panel" parent="SkillMenu"]
-custom_minimum_size = Vector2(1600, 800)
+[node name="TabBar" type="TabBar" parent="SkillMenu"]
 layout_mode = 0
 offset_right = 40.0
 offset_bottom = 40.0
+tab_count = 2
+clip_tabs = false
+tab_0/title = "Character 1"
+tab_1/title = "Character 2"
+
+[node name="SkillPanel" type="Panel" parent="SkillMenu"]
+custom_minimum_size = Vector2(1500, 800)
+layout_mode = 0
+offset_top = 40.0
+offset_right = 40.0
+offset_bottom = 80.0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="SkillMenu/SkillPanel"]
+layout_mode = 0
+offset_left = 352.0
+offset_top = 24.0
+offset_right = 452.0
+offset_bottom = 124.0
+
+[node name="SkillMenuButton" type="TextureButton" parent="SkillMenu/SkillPanel/HBoxContainer"]
+layout_mode = 2
+texture_normal = ExtResource("2_wplbt")
+script = ExtResource("3_ab0j6")
+
+[node name="SkillDescriptionPanel" type="Panel" parent="SkillMenu/SkillPanel"]
+custom_minimum_size = Vector2(300, 500)
+layout_mode = 0
+offset_left = 32.0
+offset_top = 24.0
+offset_right = 182.0
+offset_bottom = 99.0
+
+[node name="SkillDescriptionLabel" type="RichTextLabel" parent="SkillMenu/SkillPanel/SkillDescriptionPanel"]
+layout_mode = 2
+offset_left = 24.0
+offset_top = 20.0
+offset_right = 274.0
+offset_bottom = 320.0
+bbcode_enabled = true
+text = "[b]Skills name[/b]
+Skill description
+Later maybe add a portrait in this panel, where we will overlay the skill description on top"
+
+[node name="ExitButton" type="Button" parent="SkillMenu"]
+custom_minimum_size = Vector2(50, 0)
+layout_mode = 0
+offset_left = 1450.0
+offset_top = 8.0
+offset_right = 1500.0
+offset_bottom = 39.0
+text = "X"

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=2 format=3 uid="uid://dks4qxa6s4ful"]
+
+[ext_resource type="Script" path="res://Scripts/UI/Skill/SkillMenu.gd" id="1_gb7ft"]
+
+[node name="SkillMenu" type="CanvasLayer"]
+
+[node name="SkillMenu" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+script = ExtResource("1_gb7ft")
+
+[node name="Panel" type="Panel" parent="SkillMenu"]
+custom_minimum_size = Vector2(1600, 800)
+layout_mode = 0
+offset_right = 40.0
+offset_bottom = 40.0

--- a/Scripts/Battle/Combatant.gd
+++ b/Scripts/Battle/Combatant.gd
@@ -16,6 +16,9 @@ var stats: Dictionary = {}
 ## The status effects being monitored for this character.
 var status_effect_holder: StatusEffectHolder = StatusEffectHolder.new()
 
+## The skills being monitored for this character.
+var skill_holder: SkillHolder = SkillHolder.new()
+
 ## Initialize the stats. This base class just gives default values
 func initialize() -> void:
 	# Attributes

--- a/Scripts/Battle/PlayerCombatant.gd
+++ b/Scripts/Battle/PlayerCombatant.gd
@@ -59,7 +59,7 @@ func initialize_with_class_data(class_data: CharacterClass) -> void:
 		true
 	)
 	
-	# TODO: Set the default skills, if any?
+	skill_holder.initialize(class_data.skills)
 
 ## Initialize the player character based on another player character.
 func initialize_with_copy(copy: PlayerCombatant) -> void:

--- a/Scripts/Character/Skill/SkillData.gd
+++ b/Scripts/Character/Skill/SkillData.gd
@@ -42,6 +42,9 @@ class_name SkillData extends Resource
 ## Defines what a skill does.
 @export var effects: Array[SkillEffect] = []
 
+## Texture for button in skills menu
+@export var display_texture: Texture2D
+
 ## Get the needed data for the passed character.
 func get_usable_data(activator: Combatant) -> ActionMediator:
 	var action_mediator: ActionMediator = ActionMediator.new()

--- a/Scripts/Character/Skill/SkillHolder.gd
+++ b/Scripts/Character/Skill/SkillHolder.gd
@@ -1,0 +1,7 @@
+class_name SkillHolder
+
+var skills: Array[SkillInstance] = []
+
+func initialize(skills_data: Array[SkillData]):
+	for data in skills_data:
+		skills.append(SkillInstance.new(data))

--- a/Scripts/Character/Skill/SkillInstance.gd
+++ b/Scripts/Character/Skill/SkillInstance.gd
@@ -1,0 +1,9 @@
+class_name SkillInstance
+
+var monitored_skill: SkillData
+
+var current_upgrade_level: int
+
+func _init(skill: SkillData):
+	monitored_skill = skill
+	current_upgrade_level = 0

--- a/Scripts/UI/Homebase/HomebaseHome.gd
+++ b/Scripts/UI/Homebase/HomebaseHome.gd
@@ -10,6 +10,8 @@ class_name HomebaseHome extends Control
 @export var acquisition_button: BaseButton
 @export var quit_button: BaseButton
 
+@export var skill_menu: CanvasLayer
+
 func _ready() -> void:
 	# Connect the needed button events
 	missions_button.button_down.connect( on_mission_button_pressed )
@@ -20,6 +22,11 @@ func _ready() -> void:
 	missions_button.disabled = !PlayerPartyController.has_members()
 	
 	get_first_enabled_button_or_default().grab_focus()
+	skill_menu.hide()
+
+func _process(delta):
+	if (Input.is_action_just_pressed("open_skills")):
+		skill_menu.visible = !skill_menu.visible
 
 func on_mission_button_pressed() -> void:
 	SceneController.switch_to_scene( missions_scene )

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -7,6 +7,7 @@ class_name SkillMenu extends Control
 @export var skill_container: HBoxContainer
 @export var skill_points_label: Label
 @export var skill_menu_button_template: PackedScene
+@export var canvas: CanvasLayer
 
 const skills_group_name := "skills"
 
@@ -18,7 +19,7 @@ func _ready():
 	add_tabs_per_character()
 	visibility_changed.connect( on_visibility_changed )
 	tab_bar.tab_changed.connect( render_tab )
-	exit_button.button_down.connect( hide )
+	exit_button.button_down.connect( canvas.hide )
 	confirm_button.button_down.connect( confirm_points )
 	undo_skill_points_button.button_down.connect( undo_points )
 
@@ -33,9 +34,10 @@ func on_visibility_changed():
 		render_tab( tab_bar.current_tab )
 
 func render_tab(index: int):
-	current_character = characters[index]
-	show_skills()
-	set_available_skill_points( current_character.available_skill_points )
+	if (len(characters) > 0):
+		current_character = characters[index]
+		show_skills()
+		set_available_skill_points( current_character.available_skill_points )
 
 func confirm_points():
 	current_character.available_skill_points = draft_available_skill_points

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -1,0 +1,12 @@
+class_name SkillMenu extends Control
+
+@export var combatant : Combatant 
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -34,18 +34,18 @@ func on_visibility_changed():
 		render_tab( tab_bar.current_tab )
 
 func render_tab(index: int):
-	if (len(characters) > 0):
+	if (PlayerPartyController.has_members()):
 		current_character = characters[index]
 		show_skills()
-		set_available_skill_points( current_character.available_skill_points )
+		set_draft_skill_points( current_character.available_skill_points )
 
 func confirm_points():
 	current_character.available_skill_points = draft_available_skill_points
-	set_available_skill_points( current_character.available_skill_points )
+	set_draft_skill_points( current_character.available_skill_points )
 	get_tree().call_group( skills_group_name, "confirm" )
 
 func undo_points():
-	set_available_skill_points( current_character.available_skill_points )
+	set_draft_skill_points( current_character.available_skill_points )
 	get_tree().call_group( skills_group_name, "undo" )
 
 func show_skills():
@@ -62,18 +62,15 @@ func make_skill_button(skill: SkillInstance) -> SkillMenuButton:
 	return button
 
 func on_skill_upgraded():
-	undo_skill_points_button.disabled = false
-	confirm_button.disabled = false
-	set_available_skill_points( draft_available_skill_points - 1 )
-	set_available_skill_points_label()
+	set_draft_skill_points( draft_available_skill_points - 1 )
 
-func set_available_skill_points(new_value: int):
+func set_draft_skill_points(new_value: int):
 	draft_available_skill_points = new_value
-	set_available_skill_points_label()
+	set_draft_skill_points_label()
 	disable_skills_if_no_points_left()
 	disable_confirm_and_undo_if_no_action_taken()
 
-func set_available_skill_points_label():
+func set_draft_skill_points_label():
 	skill_points_label.text = "Available skill points: "
 	skill_points_label.text += str( draft_available_skill_points )
 

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -2,9 +2,9 @@ class_name SkillMenu extends Control
 
 @export var tab_bar: TabBar
 @export var exit_button: Button
+@export var undo_skill_points_button: Button
 @export var skill_container: HBoxContainer
-@export var skill_description_label: RichTextLabel
-
+@export var skill_points_label: Label
 @export var skill_menu_button_template: PackedScene
 
 var characters:= PlayerPartyController.party_members
@@ -13,27 +13,36 @@ var characters:= PlayerPartyController.party_members
 func _ready():
 	add_tabs_per_character()
 	visibility_changed.connect( on_visibility_changed )
-	tab_bar.tab_changed.connect( show_skills )
+	tab_bar.tab_changed.connect( render_tab )
 	exit_button.button_down.connect( hide )
-
-func on_visibility_changed():
-	if (visible):
-		show_skills(tab_bar.current_tab)
-
-func show_skills(index: int):
-	clear_skills()
-	var character:= characters[index]
-	for skill in character.skill_holder.skills:
-		var button := skill_menu_button_template.instantiate() as SkillMenuButton
-		button.initialize(skill, skill_description_label)
-		skill_container.add_child(button)
 
 func add_tabs_per_character():
 	tab_bar.clear_tabs()
 	for character in characters:
-		tab_bar.add_tab(character.char_name)
+		var tab_name = "[" + character.pc_class.localization_name + "] " + character.char_name
+		tab_bar.add_tab( tab_name )
+
+func on_visibility_changed():
+	if (visible):
+		render_tab( tab_bar.current_tab )
+
+func render_tab(index: int):
+	var character:= characters[index]
+	show_skills(character)
+	set_available_skill_points_label(character)
+
+func show_skills(character: PlayerCombatant):
+	clear_skills()
+	for skill in character.skill_holder.skills:
+		var button := skill_menu_button_template.instantiate() as SkillMenuButton
+		button.initialize( skill )
+		button.disabled = character.available_skill_points == 0
+		skill_container.add_child( button )
+
+func set_available_skill_points_label(character: PlayerCombatant):
+	skill_points_label.text = "Available skill points: " + str(character.available_skill_points)
 
 func clear_skills():
 	for child in skill_container.get_children():
-		skill_container.remove_child(child)
+		skill_container.remove_child( child )
 		child.queue_free()

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -1,12 +1,36 @@
 class_name SkillMenu extends Control
 
-@export var combatant : Combatant 
+@export var tab_bar: TabBar
+@export var exit_button: Button
+@export var skill_container: HBoxContainer
+@export var skill_description_label: RichTextLabel
+
+var characters:= PlayerPartyController.party_members
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	pass # Replace with function body.
+	add_tabs_per_character()
+	visibility_changed.connect( on_visibility_changed )
+	tab_bar.tab_changed.connect( show_skills )
+	exit_button.button_down.connect( hide )
 
+func on_visibility_changed():
+	if (visible):
+		show_skills(tab_bar.current_tab)
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	pass
+func show_skills(index: int):
+	clear_skills()
+	var character:= characters[index]
+	for skill in character.skill_holder.skills:
+		var button = SkillMenuButton.new(skill, skill_description_label)
+		skill_container.add_child(button)
+
+func add_tabs_per_character():
+	tab_bar.clear_tabs()
+	for character in characters:
+		tab_bar.add_tab(character.char_name)
+
+func clear_skills():
+	for child in skill_container.get_children():
+		skill_container.remove_child(child)
+		child.queue_free()

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -2,6 +2,7 @@ class_name SkillMenu extends Control
 
 @export var tab_bar: TabBar
 @export var exit_button: Button
+@export var confirm_button: Button
 @export var undo_skill_points_button: Button
 @export var skill_container: HBoxContainer
 @export var skill_points_label: Label
@@ -11,12 +12,15 @@ const skills_group_name := "skills"
 
 var characters:= PlayerPartyController.party_members
 var current_character: PlayerCombatant
+var draft_available_skill_points
 
 func _ready():
 	add_tabs_per_character()
 	visibility_changed.connect( on_visibility_changed )
 	tab_bar.tab_changed.connect( render_tab )
 	exit_button.button_down.connect( hide )
+	confirm_button.button_down.connect( confirm_points )
+	undo_skill_points_button.button_down.connect( undo_points )
 
 func add_tabs_per_character():
 	tab_bar.clear_tabs()
@@ -31,8 +35,16 @@ func on_visibility_changed():
 func render_tab(index: int):
 	current_character = characters[index]
 	show_skills()
-	check_available_skill_points()
-	set_available_skill_points_label()
+	set_available_skill_points( current_character.available_skill_points )
+
+func confirm_points():
+	current_character.available_skill_points = draft_available_skill_points
+	set_available_skill_points( current_character.available_skill_points )
+	get_tree().call_group( skills_group_name, "confirm" )
+
+func undo_points():
+	set_available_skill_points( current_character.available_skill_points )
+	get_tree().call_group( skills_group_name, "undo" )
 
 func show_skills():
 	clear_skills()
@@ -48,17 +60,29 @@ func make_skill_button(skill: SkillInstance) -> SkillMenuButton:
 	return button
 
 func on_skill_upgraded():
-	current_character.available_skill_points -= 1
+	undo_skill_points_button.disabled = false
+	confirm_button.disabled = false
+	set_available_skill_points( draft_available_skill_points - 1 )
 	set_available_skill_points_label()
-	check_available_skill_points()
 
-func check_available_skill_points():
-	if (current_character.available_skill_points == 0):
-		get_tree().call_group( skills_group_name, "disable" )
+func set_available_skill_points(new_value: int):
+	draft_available_skill_points = new_value
+	set_available_skill_points_label()
+	disable_skills_if_no_points_left()
+	disable_confirm_and_undo_if_no_action_taken()
 
 func set_available_skill_points_label():
 	skill_points_label.text = "Available skill points: "
-	skill_points_label.text += str( current_character.available_skill_points )
+	skill_points_label.text += str( draft_available_skill_points )
+
+func disable_skills_if_no_points_left():
+	var function_name = "disable" if draft_available_skill_points == 0 else "enable"
+	get_tree().call_group( skills_group_name, function_name )
+
+func disable_confirm_and_undo_if_no_action_taken():
+	var no_action_taken: bool = draft_available_skill_points == current_character.available_skill_points
+	confirm_button.disabled = no_action_taken
+	undo_skill_points_button.disabled = no_action_taken
 
 func clear_skills():
 	for child in skill_container.get_children():

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -5,6 +5,8 @@ class_name SkillMenu extends Control
 @export var skill_container: HBoxContainer
 @export var skill_description_label: RichTextLabel
 
+@export var skill_menu_button_template: PackedScene
+
 var characters:= PlayerPartyController.party_members
 
 # Called when the node enters the scene tree for the first time.
@@ -22,7 +24,8 @@ func show_skills(index: int):
 	clear_skills()
 	var character:= characters[index]
 	for skill in character.skill_holder.skills:
-		var button = SkillMenuButton.new(skill, skill_description_label)
+		var button := skill_menu_button_template.instantiate() as SkillMenuButton
+		button.initialize(skill, skill_description_label)
 		skill_container.add_child(button)
 
 func add_tabs_per_character():

--- a/Scripts/UI/Skill/SkillMenuButton.gd
+++ b/Scripts/UI/Skill/SkillMenuButton.gd
@@ -1,23 +1,15 @@
 class_name SkillMenuButton extends TextureButton
 
 var skill: SkillInstance
-var description_label: RichTextLabel
+@export var level_label: Label
 
-func initialize(_skill: SkillInstance, _description_label: RichTextLabel):
+func initialize(_skill: SkillInstance):
 	skill = _skill
-	description_label = _description_label
 	texture_normal = skill.monitored_skill.display_texture
-	description_label.hide()
-
-func _ready():
-	button_down.connect(show_description)
-
-func show_description():
-	description_label.text = get_formatted_skill_text()
-	description_label.show()
+	tooltip_text = get_formatted_skill_text()
+	level_label.text = str(skill.current_upgrade_level) + "/" + str(skill.monitored_skill.max_rank)
 
 func get_formatted_skill_text() -> String:
-	var text = "[b]" + skill.monitored_skill.localization_name + "[/b]"
-	text += "\n"
+	var text = skill.monitored_skill.localization_name + ": "
 	text += skill.monitored_skill.localization_description
 	return text

--- a/Scripts/UI/Skill/SkillMenuButton.gd
+++ b/Scripts/UI/Skill/SkillMenuButton.gd
@@ -22,7 +22,6 @@ func enable():
 
 func upgrade_skill():
 	set_upgrade_level( draft_level + 1 )
-	set_level_text()
 	emit_signal( "skill_upgraded" )
 
 func confirm():

--- a/Scripts/UI/Skill/SkillMenuButton.gd
+++ b/Scripts/UI/Skill/SkillMenuButton.gd
@@ -1,0 +1,23 @@
+class_name SkillMenuButton extends TextureButton
+
+var skill: SkillInstance
+var description_label: RichTextLabel
+
+func _init(_skill: SkillInstance, _description_label: RichTextLabel):
+	skill = _skill
+	description_label = _description_label
+
+func _ready():
+	texture_normal = skill.monitored_skill.display_texture
+	button_down.connect(show_description)
+	description_label.hide()
+
+func show_description():
+	description_label.text = get_formatted_skill_text()
+	description_label.show()
+
+func get_formatted_skill_text() -> String:
+	var text = "[b]" + skill.monitored_skill.localization_name + "[/b]"
+	text += "\n"
+	text += skill.monitored_skill.localization_description
+	return text

--- a/Scripts/UI/Skill/SkillMenuButton.gd
+++ b/Scripts/UI/Skill/SkillMenuButton.gd
@@ -3,13 +3,41 @@ class_name SkillMenuButton extends TextureButton
 var skill: SkillInstance
 @export var level_label: Label
 
+signal skill_upgraded()
+
 func initialize(_skill: SkillInstance):
 	skill = _skill
+	button_down.connect( upgrade_skill )
+	set_correct_texture_and_text()
+	
+func disable():
+	disabled = true
+	apply_grayscale()
+
+func enable():
+	disabled = false
+	unapply_grayscale()
+
+func upgrade_skill():
+	skill.current_upgrade_level += 1
+	set_level_text()
+	emit_signal("skill_upgraded")
+
+func set_correct_texture_and_text():
 	texture_normal = skill.monitored_skill.display_texture
 	tooltip_text = get_formatted_skill_text()
+	set_level_text()
+
+func set_level_text():
 	level_label.text = str(skill.current_upgrade_level) + "/" + str(skill.monitored_skill.max_rank)
 
 func get_formatted_skill_text() -> String:
 	var text = skill.monitored_skill.localization_name + ": "
 	text += skill.monitored_skill.localization_description
 	return text
+	
+func apply_grayscale():
+	modulate = Color(0.6, 0.6, 0.6, 1)
+	
+func unapply_grayscale():
+	modulate = Color(1, 1, 1, 1)

--- a/Scripts/UI/Skill/SkillMenuButton.gd
+++ b/Scripts/UI/Skill/SkillMenuButton.gd
@@ -1,6 +1,8 @@
 class_name SkillMenuButton extends TextureButton
 
 var skill: SkillInstance
+var draft_level
+
 @export var level_label: Label
 
 signal skill_upgraded()
@@ -19,17 +21,27 @@ func enable():
 	unapply_grayscale()
 
 func upgrade_skill():
-	skill.current_upgrade_level += 1
+	set_upgrade_level( draft_level + 1 )
 	set_level_text()
-	emit_signal("skill_upgraded")
+	emit_signal( "skill_upgraded" )
+
+func confirm():
+	skill.current_upgrade_level = draft_level
+
+func undo():
+	set_upgrade_level( skill.current_upgrade_level )
 
 func set_correct_texture_and_text():
 	texture_normal = skill.monitored_skill.display_texture
 	tooltip_text = get_formatted_skill_text()
+	set_upgrade_level( skill.current_upgrade_level )
+
+func set_upgrade_level(new_value: int):
+	draft_level = new_value
 	set_level_text()
 
 func set_level_text():
-	level_label.text = str(skill.current_upgrade_level) + "/" + str(skill.monitored_skill.max_rank)
+	level_label.text = str( draft_level ) + "/" + str( skill.monitored_skill.max_rank )
 
 func get_formatted_skill_text() -> String:
 	var text = skill.monitored_skill.localization_name + ": "

--- a/Scripts/UI/Skill/SkillMenuButton.gd
+++ b/Scripts/UI/Skill/SkillMenuButton.gd
@@ -3,14 +3,14 @@ class_name SkillMenuButton extends TextureButton
 var skill: SkillInstance
 var description_label: RichTextLabel
 
-func _init(_skill: SkillInstance, _description_label: RichTextLabel):
+func initialize(_skill: SkillInstance, _description_label: RichTextLabel):
 	skill = _skill
 	description_label = _description_label
+	texture_normal = skill.monitored_skill.display_texture
+	description_label.hide()
 
 func _ready():
-	texture_normal = skill.monitored_skill.display_texture
 	button_down.connect(show_description)
-	description_label.hide()
 
 func show_description():
 	description_label.text = get_formatted_skill_text()

--- a/project.godot
+++ b/project.godot
@@ -53,3 +53,8 @@ ui_cancel={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":1,"pressure":0.0,"pressed":true,"script":null)
 ]
 }
+open_skills={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194306,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}

--- a/project.godot
+++ b/project.godot
@@ -55,6 +55,6 @@ ui_cancel={
 }
 open_skills={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194306,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":83,"physical_keycode":0,"key_label":0,"unicode":115,"echo":false,"script":null)
 ]
 }


### PR DESCRIPTION
## Changes
* Skills Menu can be opened by pressing S (changed from Tab because Tab would also move the focus on the buttons)
* Menu will spawn a tab for each character
* Menu will spawn skill buttons and show their description on click
* Player can assign skill points to party members with confirm and undo actions

**Implementation details:**
* `SkillMenuButton` will take care of upgrading the skill instance, and emit a `skill_upgraded` signal
* `SkillMenu` will subscribe to `skill_upgraded` and take care of the available points to spend

I put some test code in to give Aegis class 3 starting points. That's how I tested this (also checked that test code is not committed)
![Animation](https://github.com/EveningComet/Project-Horizon/assets/33893929/d58d1c75-96ee-423a-89d6-fbdd69d8b3a3)

The tooltip:
![image](https://github.com/EveningComet/Project-Horizon/assets/33893929/227c086d-009c-4b27-8bf5-8ad37539ce1d)
