### PR TITLE
[SkillsMenu] Upgrading skill now unlocks next skills

### DIFF
--- a/Game Data/Player Character Classes/Class Skills/Aegis Skills/Aegis Pulse Beam.tres
+++ b/Game Data/Player Character Classes/Class Skills/Aegis Skills/Aegis Pulse Beam.tres
@@ -1,8 +1,9 @@
-[gd_resource type="Resource" script_class="SkillData" load_steps=5 format=3 uid="uid://cydkltv3usq2l"]
+[gd_resource type="Resource" script_class="SkillData" load_steps=6 format=3 uid="uid://cydkltv3usq2l"]
 
 [ext_resource type="Script" path="res://Scripts/Character/Skill/Skill Effects/DirectDamage.gd" id="1_2lgx2"]
 [ext_resource type="Script" path="res://Scripts/Character/Skill/SkillData.gd" id="1_m3w6m"]
 [ext_resource type="Texture2D" uid="uid://qd1gmfqfgvyb" path="res://Imported Assets/UI/Wenrexa UI Kit #4/Icons/Icon35.png" id="1_tmpa6"]
+[ext_resource type="Resource" uid="uid://c0h3wsdqfllab" path="res://Game Data/Player Character Classes/Class Skills/Aegis Skills/Aegis Shell.tres" id="4_87x5o"]
 
 [sub_resource type="Resource" id="Resource_pol7e"]
 script = ExtResource("1_2lgx2")
@@ -22,7 +23,8 @@ minimum_rank_of_previous = 1
 base_power_scale = 1.0
 upgrade_scale = 5.0
 success_chance = 1.0
-unlockable = Array[ExtResource("1_m3w6m")]([])
+is_unlocked_by_default = true
+unlockable = Array[ExtResource("1_m3w6m")]([ExtResource("4_87x5o")])
 is_ranged = false
 effects = Array[Resource("res://Scripts/Character/Skill/Skill Effects/SkillEffect.gd")]([SubResource("Resource_pol7e")])
 display_texture = ExtResource("1_tmpa6")

--- a/Game Data/Player Character Classes/Class Skills/Seeker Skills/Seeker Field Medicine.tres
+++ b/Game Data/Player Character Classes/Class Skills/Seeker Skills/Seeker Field Medicine.tres
@@ -22,6 +22,7 @@ minimum_rank_of_previous = 1
 base_power_scale = 1.0
 upgrade_scale = 5.0
 success_chance = 1.0
+is_unlocked_by_default = true
 unlockable = Array[ExtResource("1_g62jx")]([])
 is_ranged = false
 effects = Array[Resource("res://Scripts/Character/Skill/Skill Effects/SkillEffect.gd")]([SubResource("Resource_3qk50")])

--- a/Scripts/Character/Skill/SkillData.gd
+++ b/Scripts/Character/Skill/SkillData.gd
@@ -33,6 +33,9 @@ class_name SkillData extends Resource
 ## For skills that need a success chance, what is the base chance of succeeding?
 @export_range(0.0, 1.0) var success_chance: float = 1.0
 
+## If the skill is unlocked by default
+@export var is_unlocked_by_default: bool = false
+
 ## The skills that get unlocked based on the rank of this skill.
 @export var unlockable: Array[SkillData] = []
 

--- a/Scripts/Character/Skill/SkillHolder.gd
+++ b/Scripts/Character/Skill/SkillHolder.gd
@@ -1,7 +1,15 @@
 class_name SkillHolder
 
-var skills: Array[SkillInstance] = []
+# Dictionary { skill_data : skill_instance }
+var skill_data_instances: = {}
 
 func initialize(skills_data: Array[SkillData]):
 	for data in skills_data:
-		skills.append(SkillInstance.new(data))
+		skill_data_instances[data] = SkillInstance.new(data, on_new_skills_unlocked)
+
+func skills() -> Array:
+	return skill_data_instances.values()
+
+func on_new_skills_unlocked(skill: SkillInstance, unlocked: Array[SkillData]):
+	for data in unlocked:
+		skill_data_instances[data].unlock()

--- a/Scripts/Character/Skill/SkillInstance.gd
+++ b/Scripts/Character/Skill/SkillInstance.gd
@@ -22,6 +22,7 @@ func subscribe_skill_unlocked(callback: Callable):
 func upgrade_to_level(new_level: int):
 	current_upgrade_level = new_level
 	var new_skills := get_new_unlocked_skills()
+	unlocked_skills.append_array( new_skills )
 	if (not new_skills.is_empty()):
 		on_new_skills_unlocked.call( self, new_skills )
 

--- a/Scripts/Character/Skill/SkillInstance.gd
+++ b/Scripts/Character/Skill/SkillInstance.gd
@@ -1,9 +1,10 @@
 class_name SkillInstance
 
 var monitored_skill: SkillData
-
 var current_upgrade_level: int
+var is_unlocked: bool
 
 func _init(skill: SkillData):
 	monitored_skill = skill
 	current_upgrade_level = 0
+	is_unlocked = monitored_skill.is_unlocked_by_default

--- a/Scripts/Character/Skill/SkillInstance.gd
+++ b/Scripts/Character/Skill/SkillInstance.gd
@@ -1,10 +1,39 @@
 class_name SkillInstance
 
 var monitored_skill: SkillData
-var current_upgrade_level: int
-var is_unlocked: bool
+var unlocked_skills: Array[SkillData]
 
-func _init(skill: SkillData):
+var is_unlocked: bool
+var current_upgrade_level: int
+
+var on_this_skill_unlocked: Callable
+var on_new_skills_unlocked: Callable
+
+func _init(skill: SkillData, _on_new_skills_unlocked: Callable):
 	monitored_skill = skill
+	unlocked_skills = []
 	current_upgrade_level = 0
 	is_unlocked = monitored_skill.is_unlocked_by_default
+	on_new_skills_unlocked = _on_new_skills_unlocked
+
+func subscribe_skill_unlocked(callback: Callable):
+	on_this_skill_unlocked = callback
+
+func upgrade_to_level(new_level: int):
+	current_upgrade_level = new_level
+	var new_skills := get_new_unlocked_skills()
+	if (not new_skills.is_empty()):
+		on_new_skills_unlocked.call(self, new_skills)
+
+func unlock():
+	is_unlocked = true
+	if (not on_this_skill_unlocked.is_null()):
+		on_this_skill_unlocked.call()
+
+func get_new_unlocked_skills() -> Array[SkillData]:
+	var new_skills: Array[SkillData] = []
+	for skill in monitored_skill.unlockable:
+		var can_unlock := current_upgrade_level >= skill.minimum_rank_of_previous
+		if (can_unlock and not unlocked_skills.has(skill)):
+			new_skills.append(skill)
+	return new_skills

--- a/Scripts/Character/Skill/SkillInstance.gd
+++ b/Scripts/Character/Skill/SkillInstance.gd
@@ -23,7 +23,7 @@ func upgrade_to_level(new_level: int):
 	current_upgrade_level = new_level
 	var new_skills := get_new_unlocked_skills()
 	if (not new_skills.is_empty()):
-		on_new_skills_unlocked.call(self, new_skills)
+		on_new_skills_unlocked.call( self, new_skills )
 
 func unlock():
 	is_unlocked = true
@@ -33,7 +33,12 @@ func unlock():
 func get_new_unlocked_skills() -> Array[SkillData]:
 	var new_skills: Array[SkillData] = []
 	for skill in monitored_skill.unlockable:
-		var can_unlock := current_upgrade_level >= skill.minimum_rank_of_previous
-		if (can_unlock and not unlocked_skills.has(skill)):
-			new_skills.append(skill)
+		if (not skill_already_unlocked( skill ) and can_unlock_skill( skill )):
+			new_skills.append( skill )
 	return new_skills
+
+func can_unlock_skill(skill: SkillData):
+	return current_upgrade_level >= skill.minimum_rank_of_previous
+
+func skill_already_unlocked(skill: SkillData):
+	return unlocked_skills.has( skill )

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -75,8 +75,8 @@ func set_draft_skill_points_label():
 	skill_points_label.text += str( draft_available_skill_points )
 
 func disable_skills_if_no_points_left():
-	var function_name = "disable" if draft_available_skill_points == 0 else "enable"
-	get_tree().call_group( skills_group_name, function_name )
+	if (draft_available_skill_points == 0):
+		get_tree().call_group( skills_group_name, "disable" )
 
 func disable_confirm_and_undo_if_no_action_taken():
 	var no_action_taken: bool = draft_available_skill_points == current_character.available_skill_points

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -50,7 +50,7 @@ func undo_points():
 
 func show_skills():
 	clear_skills()
-	for skill in current_character.skill_holder.skills:
+	for skill in current_character.skill_holder.skills():
 		var button:= make_skill_button( skill )
 		skill_container.add_child( button )
 

--- a/Scripts/UI/Skill/SkillMenuButton.gd
+++ b/Scripts/UI/Skill/SkillMenuButton.gd
@@ -11,6 +11,7 @@ func initialize(_skill: SkillInstance):
 	skill = _skill
 	button_down.connect( upgrade_skill )
 	set_correct_texture_and_text()
+	enable_button_if_skill_unlocked()
 	
 func disable():
 	disabled = true
@@ -29,6 +30,12 @@ func confirm():
 
 func undo():
 	set_upgrade_level( skill.current_upgrade_level )
+
+func enable_button_if_skill_unlocked():
+	if (skill.is_unlocked):
+		enable()
+	else:
+		disable()
 
 func set_correct_texture_and_text():
 	texture_normal = skill.monitored_skill.display_texture

--- a/Scripts/UI/Skill/SkillMenuButton.gd
+++ b/Scripts/UI/Skill/SkillMenuButton.gd
@@ -32,6 +32,7 @@ func confirm():
 
 func undo():
 	set_upgrade_level( skill.current_upgrade_level )
+	enable_button_if_skill_unlocked()
 
 func enable_button_if_skill_unlocked():
 	if (skill.is_unlocked):

--- a/Scripts/UI/Skill/SkillMenuButton.gd
+++ b/Scripts/UI/Skill/SkillMenuButton.gd
@@ -9,6 +9,8 @@ signal skill_upgraded()
 
 func initialize(_skill: SkillInstance):
 	skill = _skill
+	skill.subscribe_skill_unlocked( 
+		enable_button_if_skill_unlocked )
 	button_down.connect( upgrade_skill )
 	set_correct_texture_and_text()
 	enable_button_if_skill_unlocked()
@@ -26,7 +28,7 @@ func upgrade_skill():
 	emit_signal( "skill_upgraded" )
 
 func confirm():
-	skill.current_upgrade_level = draft_level
+	skill.upgrade_to_level( draft_level )
 
 func undo():
 	set_upgrade_level( skill.current_upgrade_level )


### PR DESCRIPTION
## Changes
* `SkillInstance` now tracks an unlocked status and the unlocked skills
* `SkillInstance` now accepts 2 callbacks: `on_new_skills_unlocked`, and `on_skill_unlocked`
* `SkillHolder` uses `on_new_skills_unlocked` to unlock the right instances
* `SkillMenuButton` uses the `on_skill_unlocked` to render the button

![image](https://github.com/EveningComet/Project-Horizon/assets/33893929/92cc3972-2176-4391-937c-a87b7e2497ff)


Put in some test code again to test:
![Animation](https://github.com/EveningComet/Project-Horizon/assets/33893929/68dce024-2807-4012-95be-f260f9e2769d)


