### PR TITLE
[SkillsMenu] Fix max rank and starting level

### DIFF
--- a/Game Data/Player Character Classes/Class Skills/Aegis Skills/Aegis Shell.tres
+++ b/Game Data/Player Character Classes/Class Skills/Aegis Skills/Aegis Shell.tres
@@ -22,6 +22,7 @@ minimum_rank_of_previous = 1
 base_power_scale = 1.0
 upgrade_scale = 5.0
 success_chance = 1.0
+is_unlocked_by_default = false
 unlockable = Array[ExtResource("1_koweo")]([])
 is_ranged = false
 effects = Array[Resource("res://Scripts/Character/Skill/Skill Effects/SkillEffect.gd")]([SubResource("Resource_g3mnm")])

--- a/Scripts/Character/Skill/SkillHolder.gd
+++ b/Scripts/Character/Skill/SkillHolder.gd
@@ -12,4 +12,5 @@ func skills() -> Array:
 
 func on_new_skills_unlocked(skill: SkillInstance, unlocked: Array[SkillData]):
 	for data in unlocked:
-		skill_data_instances[data].unlock()
+		if (skill_data_instances.has(data)):
+			skill_data_instances[data].unlock()

--- a/Scripts/Character/Skill/SkillInstance.gd
+++ b/Scripts/Character/Skill/SkillInstance.gd
@@ -13,8 +13,10 @@ func _init(skill: SkillData, _on_new_skills_unlocked: Callable):
 	monitored_skill = skill
 	unlocked_skills = []
 	current_upgrade_level = 0
-	is_unlocked = monitored_skill.is_unlocked_by_default
 	on_new_skills_unlocked = _on_new_skills_unlocked
+	if (monitored_skill.is_unlocked_by_default):
+		unlock()
+		upgrade_to_level( 1 )
 
 func subscribe_skill_unlocked(callback: Callable):
 	on_this_skill_unlocked = callback
@@ -39,7 +41,7 @@ func get_new_unlocked_skills() -> Array[SkillData]:
 	return new_skills
 
 func can_unlock_skill(skill: SkillData):
-	return current_upgrade_level >= skill.minimum_rank_of_previous
+	return current_upgrade_level > skill.minimum_rank_of_previous
 
 func skill_already_unlocked(skill: SkillData):
 	return unlocked_skills.has( skill )

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -9,6 +9,7 @@ class_name SkillMenu extends Control
 @export var skill_menu_button_template: PackedScene
 @export var canvas: CanvasLayer
 
+signal skill_points_depleted
 const skills_group_name := "skills"
 
 var characters:= PlayerPartyController.party_members
@@ -56,7 +57,7 @@ func show_skills():
 
 func make_skill_button(skill: SkillInstance) -> SkillMenuButton:
 	var button := skill_menu_button_template.instantiate() as SkillMenuButton
-	button.initialize( skill )
+	button.initialize( skill, skill_points_depleted )
 	button.add_to_group( skills_group_name )
 	button.skill_upgraded.connect( on_skill_upgraded )
 	return button
@@ -66,17 +67,14 @@ func on_skill_upgraded():
 
 func set_draft_skill_points(new_value: int):
 	draft_available_skill_points = new_value
+	if (draft_available_skill_points == 0):
+		emit_signal("skill_points_depleted")
 	set_draft_skill_points_label()
-	disable_skills_if_no_points_left()
 	disable_confirm_and_undo_if_no_action_taken()
 
 func set_draft_skill_points_label():
 	skill_points_label.text = "Available skill points: "
 	skill_points_label.text += str( draft_available_skill_points )
-
-func disable_skills_if_no_points_left():
-	if (draft_available_skill_points == 0):
-		get_tree().call_group( skills_group_name, "disable" )
 
 func disable_confirm_and_undo_if_no_action_taken():
 	var no_action_taken: bool = draft_available_skill_points == current_character.available_skill_points

--- a/Scripts/UI/Skill/SkillMenuButton.gd
+++ b/Scripts/UI/Skill/SkillMenuButton.gd
@@ -7,13 +7,12 @@ var draft_level
 
 signal skill_upgraded()
 
-func initialize(_skill: SkillInstance):
+func initialize(_skill: SkillInstance, _points_depleted_signal: Signal):
 	skill = _skill
-	skill.subscribe_skill_unlocked( 
-		enable_button_if_skill_unlocked )
+	skill.subscribe_skill_unlocked( enable_button_if_possible )
 	button_down.connect( upgrade_skill )
+	_points_depleted_signal.connect( disable )
 	set_correct_texture_and_text()
-	enable_button_if_skill_unlocked()
 	
 func disable():
 	disabled = true
@@ -32,13 +31,6 @@ func confirm():
 
 func undo():
 	set_upgrade_level( skill.current_upgrade_level )
-	enable_button_if_skill_unlocked()
-
-func enable_button_if_skill_unlocked():
-	if (skill.is_unlocked):
-		enable()
-	else:
-		disable()
 
 func set_correct_texture_and_text():
 	texture_normal = skill.monitored_skill.display_texture
@@ -48,6 +40,7 @@ func set_correct_texture_and_text():
 func set_upgrade_level(new_value: int):
 	draft_level = new_value
 	set_level_text()
+	enable_button_if_possible()
 
 func set_level_text():
 	level_label.text = str( draft_level ) + "/" + str( skill.monitored_skill.max_rank )
@@ -62,3 +55,10 @@ func apply_grayscale():
 	
 func unapply_grayscale():
 	modulate = Color(1, 1, 1, 1)
+
+func enable_button_if_possible():
+	var is_maxed_out: bool = draft_level >= skill.monitored_skill.max_rank
+	if (skill.is_unlocked and not is_maxed_out):
+		enable()
+	else:
+		disable()


### PR DESCRIPTION
## Changes
* Bug fixed: going over skill's max rank and not having starting level
* Enable/disable of buttons moved fully into `SkillMenuButton`: in `enable_button_if_possible()` and on `skill_points_depleted` signal