### PR TITLE
[SkillsMenu] Make a skills tree by drawing lines from a skill and their unlockables

### DIFF
--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -1,11 +1,12 @@
-[gd_scene load_steps=3 format=3 uid="uid://dks4qxa6s4ful"]
+[gd_scene load_steps=4 format=3 uid="uid://dks4qxa6s4ful"]
 
 [ext_resource type="Script" path="res://Scripts/UI/Skill/SkillMenu.gd" id="1_gb7ft"]
 [ext_resource type="PackedScene" uid="uid://bngujmgvwnby5" path="res://Scenes/UI/Skill/Skill Menu Button.tscn" id="2_44m12"]
+[ext_resource type="Script" path="res://Scripts/UI/Skill/SkillsTreeRenderer.gd" id="3_3kt4c"]
 
 [node name="SkillMenu" type="CanvasLayer"]
 
-[node name="SkillMenu" type="Control" parent="." node_paths=PackedStringArray("tab_bar", "exit_button", "confirm_button", "undo_skill_points_button", "skill_container", "skill_points_label", "canvas")]
+[node name="SkillMenu" type="Control" parent="." node_paths=PackedStringArray("tab_bar", "exit_button", "confirm_button", "undo_skill_points_button", "skill_points_label", "canvas", "skills_tree_renderer")]
 layout_mode = 3
 anchors_preset = 0
 offset_left = 399.0
@@ -17,10 +18,15 @@ tab_bar = NodePath("TabBar")
 exit_button = NodePath("ExitButton")
 confirm_button = NodePath("SkillPanel/ConfirmButton")
 undo_skill_points_button = NodePath("SkillPanel/UndoSkillPointsButton")
-skill_container = NodePath("SkillPanel/HBoxContainer")
 skill_points_label = NodePath("SkillPanel/SkillPointsLabel")
-skill_menu_button_template = ExtResource("2_44m12")
 canvas = NodePath("..")
+skills_tree_renderer = NodePath("SkillsTreeRenderer")
+
+[node name="SkillsTreeRenderer" type="Node" parent="SkillMenu" node_paths=PackedStringArray("skill_container", "wait_skills_render_timer")]
+script = ExtResource("3_3kt4c")
+skill_container = NodePath("../SkillPanel/ScrollContainer/VBoxContainer/MarginContainer/HBoxContainer")
+skill_menu_button_template = ExtResource("2_44m12")
+wait_skills_render_timer = NodePath("../../WaitSkillsRenderTimer")
 
 [node name="TabBar" type="TabBar" parent="SkillMenu"]
 layout_mode = 0
@@ -38,14 +44,25 @@ offset_top = 40.0
 offset_right = 40.0
 offset_bottom = 80.0
 
-[node name="HBoxContainer" type="HBoxContainer" parent="SkillMenu/SkillPanel"]
-layout_mode = 1
-offset_left = 32.0
-offset_top = 37.0
-offset_right = 132.0
-offset_bottom = 137.0
+[node name="ScrollContainer" type="ScrollContainer" parent="SkillMenu/SkillPanel"]
+layout_mode = 0
+offset_right = 1499.0
+offset_bottom = 723.0
 
-[node name="PartyEmptyLabel" type="Label" parent="SkillMenu/SkillPanel/HBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="SkillMenu/SkillPanel/ScrollContainer"]
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="SkillMenu/SkillPanel/ScrollContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 15
+theme_override_constants/margin_top = 15
+theme_override_constants/margin_right = 15
+theme_override_constants/margin_bottom = 15
+
+[node name="HBoxContainer" type="HBoxContainer" parent="SkillMenu/SkillPanel/ScrollContainer/VBoxContainer/MarginContainer"]
+layout_mode = 2
+
+[node name="PartyEmptyLabel" type="Label" parent="SkillMenu/SkillPanel/ScrollContainer/VBoxContainer/MarginContainer/HBoxContainer"]
 layout_mode = 2
 text = "No members recruited"
 
@@ -85,3 +102,7 @@ offset_top = 8.0
 offset_right = 1500.0
 offset_bottom = 39.0
 text = "X"
+
+[node name="WaitSkillsRenderTimer" type="Timer" parent="."]
+wait_time = 0.1
+one_shot = true

--- a/Scripts/Character/Skill/SkillHolder.gd
+++ b/Scripts/Character/Skill/SkillHolder.gd
@@ -6,6 +6,7 @@ var skill_data_instances: = {}
 func initialize(skills_data: Array[SkillData]):
 	for data in skills_data:
 		skill_data_instances[data] = SkillInstance.new(data, on_new_skills_unlocked)
+	unlock_and_upgrade_starting_skills()
 
 func skills() -> Array:
 	return skill_data_instances.values()
@@ -14,3 +15,9 @@ func on_new_skills_unlocked(skill: SkillInstance, unlocked: Array[SkillData]):
 	for data in unlocked:
 		if (skill_data_instances.has(data)):
 			skill_data_instances[data].unlock()
+
+func unlock_and_upgrade_starting_skills():
+	for data in skill_data_instances.keys():
+		if (data.is_unlocked_by_default):
+			skill_data_instances[data].unlock()	
+			skill_data_instances[data].upgrade_to_level( 1 )	

--- a/Scripts/Character/Skill/SkillInstance.gd
+++ b/Scripts/Character/Skill/SkillInstance.gd
@@ -14,9 +14,6 @@ func _init(skill: SkillData, _on_new_skills_unlocked: Callable):
 	unlocked_skills = []
 	current_upgrade_level = 0
 	on_new_skills_unlocked = _on_new_skills_unlocked
-	if (monitored_skill.is_unlocked_by_default):
-		unlock()
-		upgrade_to_level( 1 )
 
 func subscribe_skill_unlocked(callback: Callable):
 	on_this_skill_unlocked = callback
@@ -38,10 +35,11 @@ func get_new_unlocked_skills() -> Array[SkillData]:
 	for skill in monitored_skill.unlockable:
 		if (not skill_already_unlocked( skill ) and can_unlock_skill( skill )):
 			new_skills.append( skill )
+			print(monitored_skill.localization_name, " unlocked ", skill.localization_name)
 	return new_skills
 
 func can_unlock_skill(skill: SkillData):
-	return current_upgrade_level > skill.minimum_rank_of_previous
+	return current_upgrade_level >= skill.minimum_rank_of_previous
 
 func skill_already_unlocked(skill: SkillData):
 	return unlocked_skills.has( skill )

--- a/Scripts/Character/Skill/SkillInstance.gd
+++ b/Scripts/Character/Skill/SkillInstance.gd
@@ -35,7 +35,6 @@ func get_new_unlocked_skills() -> Array[SkillData]:
 	for skill in monitored_skill.unlockable:
 		if (not skill_already_unlocked( skill ) and can_unlock_skill( skill )):
 			new_skills.append( skill )
-			print(monitored_skill.localization_name, " unlocked ", skill.localization_name)
 	return new_skills
 
 func can_unlock_skill(skill: SkillData):

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -21,7 +21,7 @@ func _ready():
 	exit_button.button_down.connect( canvas.hide )
 	confirm_button.button_down.connect( confirm_points )
 	undo_skill_points_button.button_down.connect( undo_points )
-	skills_tree_renderer.initialize(on_skill_upgraded, skill_points_depleted)
+	skills_tree_renderer.initialize( on_skill_upgraded, skill_points_depleted )
 
 func add_tabs_per_character():
 	tab_bar.clear_tabs()

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -4,13 +4,11 @@ class_name SkillMenu extends Control
 @export var exit_button: Button
 @export var confirm_button: Button
 @export var undo_skill_points_button: Button
-@export var skill_container: HBoxContainer
 @export var skill_points_label: Label
-@export var skill_menu_button_template: PackedScene
 @export var canvas: CanvasLayer
+@export var skills_tree_renderer: SkillsTreeRenderer
 
 signal skill_points_depleted
-const skills_group_name := "skills"
 
 var characters:= PlayerPartyController.party_members
 var current_character: PlayerCombatant
@@ -23,6 +21,7 @@ func _ready():
 	exit_button.button_down.connect( canvas.hide )
 	confirm_button.button_down.connect( confirm_points )
 	undo_skill_points_button.button_down.connect( undo_points )
+	skills_tree_renderer.initialize(on_skill_upgraded, skill_points_depleted)
 
 func add_tabs_per_character():
 	tab_bar.clear_tabs()
@@ -37,30 +36,17 @@ func on_visibility_changed():
 func render_tab(index: int):
 	if (PlayerPartyController.has_members()):
 		current_character = characters[index]
-		show_skills()
+		skills_tree_renderer.start(current_character.skill_holder.skills())
 		set_draft_skill_points( current_character.available_skill_points )
 
 func confirm_points():
 	current_character.available_skill_points = draft_available_skill_points
 	set_draft_skill_points( current_character.available_skill_points )
-	get_tree().call_group( skills_group_name, "confirm" )
+	get_tree().call_group( skills_tree_renderer.skills_group_name, "confirm" )
 
 func undo_points():
 	set_draft_skill_points( current_character.available_skill_points )
-	get_tree().call_group( skills_group_name, "undo" )
-
-func show_skills():
-	clear_skills()
-	for skill in current_character.skill_holder.skills():
-		var button:= make_skill_button( skill )
-		skill_container.add_child( button )
-
-func make_skill_button(skill: SkillInstance) -> SkillMenuButton:
-	var button := skill_menu_button_template.instantiate() as SkillMenuButton
-	button.initialize( skill, skill_points_depleted )
-	button.add_to_group( skills_group_name )
-	button.skill_upgraded.connect( on_skill_upgraded )
-	return button
+	get_tree().call_group( skills_tree_renderer.skills_group_name, "undo" )
 
 func on_skill_upgraded():
 	set_draft_skill_points( draft_available_skill_points - 1 )
@@ -80,8 +66,3 @@ func disable_confirm_and_undo_if_no_action_taken():
 	var no_action_taken: bool = draft_available_skill_points == current_character.available_skill_points
 	confirm_button.disabled = no_action_taken
 	undo_skill_points_button.disabled = no_action_taken
-
-func clear_skills():
-	for child in skill_container.get_children():
-		skill_container.remove_child( child )
-		child.queue_free()

--- a/Scripts/UI/Skill/SkillsTreeRenderer.gd
+++ b/Scripts/UI/Skill/SkillsTreeRenderer.gd
@@ -1,10 +1,10 @@
-# Spawns and draws the skills tree
+## This node spawns the skills tree
+## by spawning the buttons and their connecting lines
 class_name SkillsTreeRenderer extends Node
 
 @export var skill_container: HBoxContainer
 @export var skill_menu_button_template: PackedScene
 @export var wait_skills_render_timer: Timer
-
 @export var skills_group_name : String = "skills"
 
 # Dictionary { skill_data : skill_menu_button }
@@ -14,6 +14,7 @@ var on_skill_upgraded: Callable
 var skill_points_depleted: Signal
 
 func _ready():
+	# The buttons must first render before we can get their position for drawing lines
 	wait_skills_render_timer.timeout.connect( finish )
 
 func initialize(_on_skill_upgraded: Callable, _skill_points_depleted: Signal):
@@ -25,36 +26,40 @@ func start(skills: Array):
 	for skill in skills:
 		var button:= make_skill_button( skill ) as SkillMenuButton
 		button_per_skill[skill.monitored_skill] = button
+		fade_in( button )
 		skill_container.add_child( button )
-	# Buttons need to render before their `position` property is correct
 	wait_skills_render_timer.start() 
 
 func finish():
 	for skill_data in button_per_skill.keys():
 		if (not skill_data.unlockable.is_empty()):
-			draw_lines_to_all_unlockables(button_per_skill[skill_data])
+			draw_lines_to_all_unlockables_from( button_per_skill[skill_data] )
 
-func draw_lines_to_all_unlockables(button: SkillMenuButton):
+func draw_lines_to_all_unlockables_from(button: SkillMenuButton):
 	var skill_data := button.skill.monitored_skill
 	var unlockables := skill_data.unlockable
 	for unlockable in unlockables:
 		var target := button_per_skill[unlockable] as SkillMenuButton
 		var line := spawn_connecting_line(button, target)
-		fade_in_line(line)
+		fade_in( line )
 		skill_container.add_child(line)
 
-func spawn_connecting_line(from: SkillMenuButton, to: SkillMenuButton) -> Line2D:
+func spawn_connecting_line(begin: SkillMenuButton, end: SkillMenuButton) -> Line2D:
 	var line := Line2D.new()
-	line.add_point(from.position + (from.size / 2))
-	line.add_point(to.position + (to.size / 2))
+	line.add_point( center_position( begin ) )
+	line.add_point( center_position( end ) )
 	line.z_index = -1 # push line to background
 	line.default_color = Color(125, 125, 125)
 	return line
 
-func fade_in_line(line: Line2D):
-	line.modulate = Color(1, 1, 1, 0)
+func center_position(item: CanvasItem):
+	return item.position + item.size / 2
+
+func fade_in(item: CanvasItem):
+	var target_modulate := item.modulate
+	item.modulate = Color(1, 1, 1, 0)
 	var tween:= get_tree().create_tween()
-	tween.tween_property(line, "modulate", Color(1, 1, 1, 1), 0.5)
+	tween.tween_property( item, "modulate", target_modulate , 0.5 )
 
 func make_skill_button(skill: SkillInstance) -> SkillMenuButton:
 	var button := skill_menu_button_template.instantiate() as SkillMenuButton

--- a/Scripts/UI/Skill/SkillsTreeRenderer.gd
+++ b/Scripts/UI/Skill/SkillsTreeRenderer.gd
@@ -1,0 +1,70 @@
+# Spawns and draws the skills tree
+class_name SkillsTreeRenderer extends Node
+
+@export var skill_container: HBoxContainer
+@export var skill_menu_button_template: PackedScene
+@export var wait_skills_render_timer: Timer
+
+@export var skills_group_name : String = "skills"
+
+# Dictionary { skill_data : skill_menu_button }
+var button_per_skill = {}
+
+var on_skill_upgraded: Callable
+var skill_points_depleted: Signal
+
+func _ready():
+	wait_skills_render_timer.timeout.connect( finish )
+
+func initialize(_on_skill_upgraded: Callable, _skill_points_depleted: Signal):
+	on_skill_upgraded = _on_skill_upgraded
+	skill_points_depleted = _skill_points_depleted
+
+func start(skills: Array):
+	clear_skills()
+	for skill in skills:
+		var button:= make_skill_button( skill ) as SkillMenuButton
+		button_per_skill[skill.monitored_skill] = button
+		skill_container.add_child( button )
+	# Buttons need to render before their `position` property is correct
+	wait_skills_render_timer.start() 
+
+func finish():
+	for skill_data in button_per_skill.keys():
+		if (not skill_data.unlockable.is_empty()):
+			draw_lines_to_all_unlockables(button_per_skill[skill_data])
+
+func draw_lines_to_all_unlockables(button: SkillMenuButton):
+	var skill_data := button.skill.monitored_skill
+	var unlockables := skill_data.unlockable
+	for unlockable in unlockables:
+		var target := button_per_skill[unlockable] as SkillMenuButton
+		var line := spawn_connecting_line(button, target)
+		fade_in_line(line)
+		skill_container.add_child(line)
+
+func spawn_connecting_line(from: SkillMenuButton, to: SkillMenuButton) -> Line2D:
+	var line := Line2D.new()
+	line.add_point(from.position + (from.size / 2))
+	line.add_point(to.position + (to.size / 2))
+	line.z_index = -1 # push line to background
+	line.default_color = Color(125, 125, 125)
+	return line
+
+func fade_in_line(line: Line2D):
+	line.modulate = Color(1, 1, 1, 0)
+	var tween:= get_tree().create_tween()
+	tween.tween_property(line, "modulate", Color(1, 1, 1, 1), 0.5)
+
+func make_skill_button(skill: SkillInstance) -> SkillMenuButton:
+	var button := skill_menu_button_template.instantiate() as SkillMenuButton
+	button.initialize( skill, skill_points_depleted )
+	button.add_to_group( skills_group_name )
+	button.skill_upgraded.connect( on_skill_upgraded )
+	return button
+
+func clear_skills():
+	for child in skill_container.get_children():
+		button_per_skill = {}
+		skill_container.remove_child( child )
+		child.queue_free()

--- a/Scripts/UI/Skill/SkillsTreeRenderer.gd
+++ b/Scripts/UI/Skill/SkillsTreeRenderer.gd
@@ -26,7 +26,6 @@ func start(skills: Array):
 	for skill in skills:
 		var button:= make_skill_button( skill ) as SkillMenuButton
 		button_per_skill[skill.monitored_skill] = button
-		fade_in( button )
 		skill_container.add_child( button )
 	wait_skills_render_timer.start() 
 

--- a/Scripts/UI/Skill/SkillsTreeRenderer.gd
+++ b/Scripts/UI/Skill/SkillsTreeRenderer.gd
@@ -39,9 +39,9 @@ func draw_lines_to_all_unlockables_from(button: SkillMenuButton):
 	var unlockables := skill_data.unlockable
 	for unlockable in unlockables:
 		var target := button_per_skill[unlockable] as SkillMenuButton
-		var line := spawn_connecting_line(button, target)
+		var line := spawn_connecting_line( button, target )
 		fade_in( line )
-		skill_container.add_child(line)
+		skill_container.add_child( line )
 
 func spawn_connecting_line(begin: SkillMenuButton, end: SkillMenuButton) -> Line2D:
 	var line := Line2D.new()


### PR DESCRIPTION
## Changes
**Features**
* Added `SkillsTreeRenderer` for spawning skill buttons and drawing lines connecting a skill and its unlockables
* Moved the spawning code out of `SkillsMenu` into `SkillsTreeRenderer`
* Updated `SkillsMenu` layout to use a `ScrollContainer`
 
![image](https://github.com/EveningComet/Project-Horizon/assets/33893929/9305ffc3-dc62-485b-b93a-ab74dac4894c)

**Bugfixes**
* Fix that when starting skills unlock other skills, it was not registered.
* Fix that the `minimum_rank` was treated as exclusive minimum, instead of inclusive.

![Animation](https://github.com/EveningComet/Project-Horizon/assets/33893929/76292c48-a1f7-4e08-ab2f-aa779bce3217)
