### PR TITLE
[Improvements] Parameterless constructor for `SkillsInstance` + resolve some warnings

### DIFF
--- a/Scripts/Character/Skill/SkillHolder.gd
+++ b/Scripts/Character/Skill/SkillHolder.gd
@@ -5,7 +5,8 @@ var skill_data_instances: = {}
 
 func initialize(skills_data: Array[SkillData]):
 	for data in skills_data:
-		skill_data_instances[data] = SkillInstance.new(data, on_new_skills_unlocked)
+		skill_data_instances[data] = SkillInstance.new()
+		skill_data_instances[data].initialize(data, on_new_skills_unlocked)
 	unlock_and_upgrade_starting_skills()
 
 func skills() -> Array:

--- a/Scripts/Character/Skill/SkillHolder.gd
+++ b/Scripts/Character/Skill/SkillHolder.gd
@@ -13,13 +13,13 @@ func skills() -> Array:
 	return skill_data_instances.values()
 
 func usable_skills() -> Array:
-	var skills = []
+	var result = []
 	for skill_instance in skill_data_instances.values():
 		if (skill_instance.is_unlocked and skill_instance.current_upgrade_level > 0):
-			skills.append(skill_instance)
-	return skills
+			result.append(skill_instance)
+	return result
 
-func on_new_skills_unlocked(skill: SkillInstance, unlocked: Array[SkillData]):
+func on_new_skills_unlocked(unlocked: Array[SkillData]):
 	for data in unlocked:
 		if (skill_data_instances.has(data)):
 			skill_data_instances[data].unlock()

--- a/Scripts/Character/Skill/SkillInstance.gd
+++ b/Scripts/Character/Skill/SkillInstance.gd
@@ -23,7 +23,7 @@ func upgrade_to_level(new_level: int):
 	var new_skills := get_new_unlocked_skills()
 	unlocked_skills.append_array( new_skills )
 	if (not new_skills.is_empty()):
-		on_new_skills_unlocked.call( self, new_skills )
+		on_new_skills_unlocked.call( new_skills )
 
 func unlock():
 	is_unlocked = true

--- a/Scripts/Character/Skill/SkillInstance.gd
+++ b/Scripts/Character/Skill/SkillInstance.gd
@@ -9,7 +9,7 @@ var current_upgrade_level: int
 var on_this_skill_unlocked: Callable
 var on_new_skills_unlocked: Callable
 
-func _init(skill: SkillData, _on_new_skills_unlocked: Callable):
+func initialize(skill: SkillData, _on_new_skills_unlocked: Callable):
 	monitored_skill = skill
 	unlocked_skills = []
 	current_upgrade_level = 0


### PR DESCRIPTION
## Changes
* Added parameterless constructor for `SkillsInstance`
* Resolved Godot warnings about unused parameters + variables being named same as function