### PR TITLE
[SkillsMenu] Add attribute points menu

### DIFF
--- a/Scenes/UI/Skill/Attribute Menu Entry.tscn
+++ b/Scenes/UI/Skill/Attribute Menu Entry.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=2 format=3 uid="uid://dq83dljr1ulfa"]
+
+[ext_resource type="Script" path="res://Scripts/UI/Skill/AttributeMenuEntry.gd" id="1_ey26o"]
+
+[node name="AttributeMenuEntry" type="HBoxContainer" node_paths=PackedStringArray("attribute_label", "upgrade_button", "downgrade_button")]
+script = ExtResource("1_ey26o")
+attribute_label = NodePath("AttributeLabel")
+upgrade_button = NodePath("UpgradeButton")
+downgrade_button = NodePath("DowngradeButton")
+
+[node name="AttributeLabel" type="Label" parent="."]
+layout_mode = 2
+text = "StatName: nn"
+
+[node name="UpgradeButton" type="Button" parent="."]
+custom_minimum_size = Vector2(25, 0)
+layout_mode = 2
+text = "+"
+
+[node name="DowngradeButton" type="Button" parent="."]
+custom_minimum_size = Vector2(25, 0)
+layout_mode = 2
+text = "-"

--- a/Scenes/UI/Skill/Attribute Menu Entry.tscn
+++ b/Scenes/UI/Skill/Attribute Menu Entry.tscn
@@ -12,6 +12,11 @@ downgrade_button = NodePath("DowngradeButton")
 layout_mode = 2
 text = "StatName: nn"
 
+[node name="EmptySpace" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
 [node name="UpgradeButton" type="Button" parent="."]
 custom_minimum_size = Vector2(25, 0)
 layout_mode = 2

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -124,7 +124,7 @@ offset_left = 24.0
 offset_top = 48.0
 offset_right = 187.0
 offset_bottom = 71.0
-text = "Points available: 0"
+text = "Available attribute points: 0"
 
 [node name="AttributesContainer" type="VBoxContainer" parent="SkillMenu/SkillPanel/AttributesPanel"]
 layout_mode = 0

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -1,12 +1,14 @@
-[gd_scene load_steps=4 format=3 uid="uid://dks4qxa6s4ful"]
+[gd_scene load_steps=6 format=3 uid="uid://dks4qxa6s4ful"]
 
 [ext_resource type="Script" path="res://Scripts/UI/Skill/SkillMenu.gd" id="1_gb7ft"]
 [ext_resource type="PackedScene" uid="uid://bngujmgvwnby5" path="res://Scenes/UI/Skill/Skill Menu Button.tscn" id="2_44m12"]
 [ext_resource type="Script" path="res://Scripts/UI/Skill/SkillsTreeRenderer.gd" id="3_3kt4c"]
+[ext_resource type="Script" path="res://Scripts/UI/Skill/AttributesMenu.gd" id="4_k8sm6"]
+[ext_resource type="PackedScene" uid="uid://dq83dljr1ulfa" path="res://Scenes/UI/Skill/Attribute Menu Entry.tscn" id="5_b7hp3"]
 
 [node name="SkillMenu" type="CanvasLayer"]
 
-[node name="SkillMenu" type="Control" parent="." node_paths=PackedStringArray("tab_bar", "exit_button", "confirm_button", "undo_skill_points_button", "skill_points_label", "canvas", "skills_tree_renderer")]
+[node name="SkillMenu" type="Control" parent="." node_paths=PackedStringArray("tab_bar", "exit_button", "confirm_button", "undo_skill_points_button", "skill_points_label", "canvas", "skills_tree_renderer", "attributes_menu")]
 layout_mode = 3
 anchors_preset = 0
 offset_left = 399.0
@@ -21,12 +23,19 @@ undo_skill_points_button = NodePath("SkillPanel/UndoSkillPointsButton")
 skill_points_label = NodePath("SkillPanel/SkillPointsLabel")
 canvas = NodePath("..")
 skills_tree_renderer = NodePath("SkillsTreeRenderer")
+attributes_menu = NodePath("AttributesMenu")
 
 [node name="SkillsTreeRenderer" type="Node" parent="SkillMenu" node_paths=PackedStringArray("skill_container", "wait_skills_render_timer")]
 script = ExtResource("3_3kt4c")
 skill_container = NodePath("../SkillPanel/ScrollContainer/VBoxContainer/MarginContainer/HBoxContainer")
 skill_menu_button_template = ExtResource("2_44m12")
 wait_skills_render_timer = NodePath("../../WaitSkillsRenderTimer")
+
+[node name="AttributesMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("points_label", "container")]
+script = ExtResource("4_k8sm6")
+points_label = NodePath("../SkillPanel/AttributesPanel/AttributePointsLabel")
+container = NodePath("../SkillPanel/AttributesPanel/AttributesContainer")
+menu_entry_template = ExtResource("5_b7hp3")
 
 [node name="TabBar" type="TabBar" parent="SkillMenu"]
 layout_mode = 0
@@ -93,6 +102,36 @@ offset_right = 1073.0
 offset_bottom = 757.0
 disabled = true
 text = "Undo points"
+
+[node name="AttributesPanel" type="Panel" parent="SkillMenu/SkillPanel"]
+layout_mode = 0
+offset_left = 1137.0
+offset_top = 67.0
+offset_right = 1417.0
+offset_bottom = 358.0
+
+[node name="AttributesHeaderLabel" type="Label" parent="SkillMenu/SkillPanel/AttributesPanel"]
+layout_mode = 0
+offset_left = 24.0
+offset_top = 24.0
+offset_right = 118.0
+offset_bottom = 47.0
+text = "Attributes"
+uppercase = true
+
+[node name="AttributePointsLabel" type="Label" parent="SkillMenu/SkillPanel/AttributesPanel"]
+offset_left = 24.0
+offset_top = 48.0
+offset_right = 187.0
+offset_bottom = 71.0
+text = "Points available: 0"
+
+[node name="AttributesContainer" type="VBoxContainer" parent="SkillMenu/SkillPanel/AttributesPanel"]
+layout_mode = 0
+offset_left = 32.0
+offset_top = 88.0
+offset_right = 72.0
+offset_bottom = 128.0
 
 [node name="ExitButton" type="Button" parent="SkillMenu"]
 custom_minimum_size = Vector2(50, 0)

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -46,8 +46,8 @@ offset_bottom = 80.0
 
 [node name="ScrollContainer" type="ScrollContainer" parent="SkillMenu/SkillPanel"]
 layout_mode = 0
-offset_right = 1499.0
-offset_bottom = 723.0
+offset_right = 1073.0
+offset_bottom = 675.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="SkillMenu/SkillPanel/ScrollContainer"]
 layout_mode = 2
@@ -77,9 +77,9 @@ text = "No available skills point"
 [node name="ConfirmButton" type="Button" parent="SkillMenu/SkillPanel"]
 custom_minimum_size = Vector2(200, 50)
 layout_mode = 0
-offset_left = 233.0
+offset_left = 673.0
 offset_top = 707.0
-offset_right = 433.0
+offset_right = 873.0
 offset_bottom = 757.0
 disabled = true
 text = "Confirm"
@@ -87,9 +87,9 @@ text = "Confirm"
 [node name="UndoSkillPointsButton" type="Button" parent="SkillMenu/SkillPanel"]
 custom_minimum_size = Vector2(200, 50)
 layout_mode = 0
-offset_left = 433.0
+offset_left = 873.0
 offset_top = 707.0
-offset_right = 633.0
+offset_right = 1073.0
 offset_bottom = 757.0
 disabled = true
 text = "Undo points"

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -31,9 +31,10 @@ skill_container = NodePath("../SkillPanel/ScrollContainer/VBoxContainer/MarginCo
 skill_menu_button_template = ExtResource("2_44m12")
 wait_skills_render_timer = NodePath("../../WaitSkillsRenderTimer")
 
-[node name="AttributesMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("points_label", "container")]
+[node name="AttributesMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("points_label", "confirm_button", "container")]
 script = ExtResource("4_k8sm6")
 points_label = NodePath("../SkillPanel/AttributesPanel/AttributePointsLabel")
+confirm_button = NodePath("../SkillPanel/AttributesPanel/ConfirmButton")
 container = NodePath("../SkillPanel/AttributesPanel/AttributesContainer")
 menu_entry_template = ExtResource("5_b7hp3")
 
@@ -132,6 +133,15 @@ offset_left = 32.0
 offset_top = 88.0
 offset_right = 72.0
 offset_bottom = 128.0
+
+[node name="ConfirmButton" type="Button" parent="SkillMenu/SkillPanel/AttributesPanel"]
+custom_minimum_size = Vector2(200, 50)
+offset_left = 40.0
+offset_top = 232.0
+offset_right = 240.0
+offset_bottom = 282.0
+disabled = true
+text = "Confirm"
 
 [node name="ExitButton" type="Button" parent="SkillMenu"]
 custom_minimum_size = Vector2(50, 0)

--- a/Scripts/Battle/PlayerCombatant.gd
+++ b/Scripts/Battle/PlayerCombatant.gd
@@ -85,3 +85,10 @@ func level_up() -> void:
 	# Give the character skill points/attribute points/etc.
 	available_attribute_points += 1
 	available_skill_points     += 3
+
+func get_attributes_increase() -> Dictionary:
+	return {
+		StatTypes.stat_types.Vitality : pc_class.vitality_on_increase,
+		StatTypes.stat_types.Expertise : pc_class.expertise_on_increase,
+		StatTypes.stat_types.Will : pc_class.will_on_increase,
+	}

--- a/Scripts/Stats/StatTypes.gd
+++ b/Scripts/Stats/StatTypes.gd
@@ -21,3 +21,15 @@ enum stat_types {
 	PhysicalPower,
 	SpecialPower
 }
+
+# Below function and variable should be static. This is a workaround.
+# Because Godot Editor will complain about static function not found
+# Even though function is declared and code runs without any runtime errors
+func attributes() -> Array[stat_types]:
+	return [ stat_types.Vitality, stat_types.Expertise, stat_types.Will ]
+
+var stat_types_to_string:= {
+	stat_types.Vitality : "Vitality",
+	stat_types.Expertise : "Expertise",
+	stat_types.Will : "Will"
+}

--- a/Scripts/UI/Skill/AttributeMenuEntry.gd
+++ b/Scripts/UI/Skill/AttributeMenuEntry.gd
@@ -17,10 +17,11 @@ var increase_amount: int = 0
 func initialize(
 	_attribute: StatTypes.stat_types,
 	_character_changed: Signal, _points_depleted: Signal, _points_available: Signal):
+	
 	attribute = _attribute
 	_character_changed.connect( update_and_render )
 	_points_depleted.connect( disable_upgrade )
-	_points_available.connect( enable_upgrade)
+	_points_available.connect( enable_upgrade )
 	upgrade_button.button_down.connect( upgrade )
 	downgrade_button.button_down.connect( downgrade )
 
@@ -40,6 +41,10 @@ func downgrade():
 		set_draft_points ( draft_points - increase_amount )
 		emit_signal("attribute_downgraded")
 
+func confirm():
+	stat.set_base_value( draft_points )
+	set_draft_points( stat.get_base_value() )
+
 func set_draft_points(points: int):
 	draft_points = points
 	update_label()
@@ -57,4 +62,4 @@ func disable_downgrade_if_minimum_reached():
 func update_label():
 	attribute_label.text = stat_types.stat_types_to_string[attribute]
 	attribute_label.text += ": "
-	attribute_label.text += str(draft_points)
+	attribute_label.text += str( draft_points )

--- a/Scripts/UI/Skill/AttributeMenuEntry.gd
+++ b/Scripts/UI/Skill/AttributeMenuEntry.gd
@@ -4,36 +4,57 @@ class_name AttributeMenuEntry extends HBoxContainer
 @export var upgrade_button: Button
 @export var downgrade_button: Button
 
+signal attribute_upgraded
+signal attribute_downgraded
+
 var stat_types := StatTypes.new()
 var attribute: StatTypes.stat_types
 
 var stat: Stat
-var draft_stat: Stat = null
+var draft_points: int = 0
 var increase_amount: int = 0
 
-func initialize(_attribute: StatTypes.stat_types, _character_changed: Signal):
+func initialize(
+	_attribute: StatTypes.stat_types,
+	_character_changed: Signal, _points_depleted: Signal, _points_available: Signal):
 	attribute = _attribute
 	_character_changed.connect( update_and_render )
+	_points_depleted.connect( disable_upgrade )
+	_points_available.connect( enable_upgrade)
 	upgrade_button.button_down.connect( upgrade )
 	downgrade_button.button_down.connect( downgrade )
 
 func update_and_render(character: PlayerCombatant):
 	stat = character.stats[attribute]
-	draft_stat = character.stats[attribute]
+	draft_points = character.stats[attribute].get_base_value()
 	increase_amount = character.get_attributes_increase()[attribute]
 	set_draft_points( stat.get_base_value() )
 
 func upgrade():
-	set_draft_points ( draft_stat.get_base_value() + increase_amount )
+	set_draft_points ( draft_points + increase_amount )
+	emit_signal("attribute_upgraded")
 
 func downgrade():
-	set_draft_points ( draft_stat.get_base_value() - increase_amount )
+	var new_amount := draft_points - increase_amount
+	if (new_amount >= stat.get_base_value()):
+		set_draft_points ( draft_points - increase_amount )
+		emit_signal("attribute_downgraded")
 
 func set_draft_points(points: int):
-	draft_stat.set_base_value( points )
+	draft_points = points
 	update_label()
+	disable_downgrade_if_minimum_reached()
+
+func enable_upgrade():
+	upgrade_button.disabled = false
+
+func disable_upgrade():
+	upgrade_button.disabled = true
+	
+func disable_downgrade_if_minimum_reached():
+	downgrade_button.disabled = draft_points <= stat.get_base_value()
 
 func update_label():
 	attribute_label.text = stat_types.stat_types_to_string[attribute]
 	attribute_label.text += ": "
-	attribute_label.text += "-" if draft_stat == null else str( draft_stat.get_base_value() )
+	attribute_label.text += str(draft_points)

--- a/Scripts/UI/Skill/AttributeMenuEntry.gd
+++ b/Scripts/UI/Skill/AttributeMenuEntry.gd
@@ -31,30 +31,30 @@ func update_and_render(character: PlayerCombatant):
 	increase_amount = character.get_attributes_increase()[attribute]
 	set_draft_points( stat.get_base_value() )
 
+func disable_upgrade():
+	upgrade_button.disabled = true
+
+func enable_upgrade():
+	upgrade_button.disabled = false
+
 func upgrade():
 	set_draft_points ( draft_points + increase_amount )
-	emit_signal("attribute_upgraded")
+	emit_signal( "attribute_upgraded" )
 
 func downgrade():
-	var new_amount := draft_points - increase_amount
-	if (new_amount >= stat.get_base_value()):
+	var is_at_minimum := draft_points == stat.get_base_value()
+	if (not is_at_minimum):
 		set_draft_points ( draft_points - increase_amount )
-		emit_signal("attribute_downgraded")
-
-func confirm():
-	stat.set_base_value( draft_points )
-	set_draft_points( stat.get_base_value() )
+		emit_signal( "attribute_downgraded" )
 
 func set_draft_points(points: int):
 	draft_points = points
 	update_label()
 	disable_downgrade_if_minimum_reached()
 
-func enable_upgrade():
-	upgrade_button.disabled = false
-
-func disable_upgrade():
-	upgrade_button.disabled = true
+func confirm():
+	stat.set_base_value( draft_points )
+	set_draft_points( stat.get_base_value() )
 	
 func disable_downgrade_if_minimum_reached():
 	downgrade_button.disabled = draft_points <= stat.get_base_value()

--- a/Scripts/UI/Skill/AttributeMenuEntry.gd
+++ b/Scripts/UI/Skill/AttributeMenuEntry.gd
@@ -1,0 +1,26 @@
+class_name AttributeMenuEntry extends HBoxContainer
+
+@export var attribute_label: Label
+@export var upgrade_button: Button
+@export var downgrade_button: Button
+
+var draft_points := 0
+var stat_types := StatTypes.new()
+
+var attribute: StatTypes.stat_types
+var stat: Stat
+
+func initialize(_attribute: StatTypes.stat_types, _character_changed: Signal):
+	attribute = _attribute
+	_character_changed.connect(render)
+	update_label()
+
+func render(character: PlayerCombatant):
+	stat = character.stats[attribute]
+	draft_points = stat.get_base_value()
+	update_label()
+
+func update_label():
+	attribute_label.text = stat_types.stat_types_to_string[attribute]
+	attribute_label.text += ": "
+	attribute_label.text += str(draft_points)

--- a/Scripts/UI/Skill/AttributeMenuEntry.gd
+++ b/Scripts/UI/Skill/AttributeMenuEntry.gd
@@ -4,23 +4,36 @@ class_name AttributeMenuEntry extends HBoxContainer
 @export var upgrade_button: Button
 @export var downgrade_button: Button
 
-var draft_points := 0
 var stat_types := StatTypes.new()
-
 var attribute: StatTypes.stat_types
+
 var stat: Stat
+var draft_stat: Stat = null
+var increase_amount: int = 0
 
 func initialize(_attribute: StatTypes.stat_types, _character_changed: Signal):
 	attribute = _attribute
-	_character_changed.connect(render)
-	update_label()
+	_character_changed.connect( update_and_render )
+	upgrade_button.button_down.connect( upgrade )
+	downgrade_button.button_down.connect( downgrade )
 
-func render(character: PlayerCombatant):
+func update_and_render(character: PlayerCombatant):
 	stat = character.stats[attribute]
-	draft_points = stat.get_base_value()
+	draft_stat = character.stats[attribute]
+	increase_amount = character.get_attributes_increase()[attribute]
+	set_draft_points( stat.get_base_value() )
+
+func upgrade():
+	set_draft_points ( draft_stat.get_base_value() + increase_amount )
+
+func downgrade():
+	set_draft_points ( draft_stat.get_base_value() - increase_amount )
+
+func set_draft_points(points: int):
+	draft_stat.set_base_value( points )
 	update_label()
 
 func update_label():
 	attribute_label.text = stat_types.stat_types_to_string[attribute]
 	attribute_label.text += ": "
-	attribute_label.text += str(draft_points)
+	attribute_label.text += "-" if draft_stat == null else str( draft_stat.get_base_value() )

--- a/Scripts/UI/Skill/AttributesMenu.gd
+++ b/Scripts/UI/Skill/AttributesMenu.gd
@@ -1,0 +1,26 @@
+class_name AttributesMenu extends Node
+
+@export var points_label: Label
+@export var container: VBoxContainer
+@export var menu_entry_template: PackedScene
+
+var character: PlayerCombatant
+var entries: Array[AttributeMenuEntry]
+var character_changed: Signal
+
+func initialize(_character_changed: Signal):
+	character_changed = _character_changed
+	character_changed.connect( update_and_render )
+	for attribute in StatTypes.new().attributes():
+		var entry := menu_entry_template.instantiate()
+		entry.initialize(attribute, character_changed)
+		entries.append(entry)
+		container.add_child(entry)
+	
+func update_and_render(_character: PlayerCombatant):
+	character = _character
+	print("AttributesMenu: ", character.char_name)
+	render()
+
+func render():
+	pass

--- a/Scripts/UI/Skill/AttributesMenu.gd
+++ b/Scripts/UI/Skill/AttributesMenu.gd
@@ -43,9 +43,9 @@ func set_draft_points(points: int):
 
 func emit_correct_signal():
 	if (draft_points == 0):
-		emit_signal("attribute_points_depleted")
+		emit_signal( "attribute_points_depleted" )
 	elif (draft_points > 0):
-		emit_signal("attribute_points_available")
+		emit_signal( "attribute_points_available" )
 
 func update_points_label():
 	points_label.text = "Available attribute points: "
@@ -62,5 +62,5 @@ func spawn_entries_for_attributes():
 			attribute, character_changed, attribute_points_depleted, attribute_points_available)
 		entry.attribute_upgraded.connect( attribute_upgraded )
 		entry.attribute_downgraded.connect( attribute_downgraded )
-		entry.add_to_group(attributes_group_name)
+		entry.add_to_group( attributes_group_name )
 		container.add_child( entry )

--- a/Scripts/UI/Skill/AttributesMenu.gd
+++ b/Scripts/UI/Skill/AttributesMenu.gd
@@ -1,6 +1,7 @@
 class_name AttributesMenu extends Node
 
 @export var points_label: Label
+@export var confirm_button: Button
 @export var container: VBoxContainer
 @export var menu_entry_template: PackedScene
 
@@ -8,37 +9,51 @@ signal attribute_points_depleted
 signal attribute_points_available
 
 var character: PlayerCombatant
-var entries: Array[AttributeMenuEntry]
 var draft_points: int = 0
 
 var character_changed: Signal
+const attributes_group_name := "attributes"
 
 func initialize(_character_changed: Signal):
 	character_changed = _character_changed
 	character_changed.connect( update_and_render )
+	confirm_button.button_down.connect( confirm )
 	spawn_entries_for_attributes()
 	
 func update_and_render(_character: PlayerCombatant):
 	character = _character
 	set_draft_points( character.available_attribute_points )
 
+func confirm():
+	character.available_attribute_points = draft_points
+	set_draft_points( character.available_attribute_points )
+	get_tree().call_group( attributes_group_name, "confirm" )
+
 func attribute_upgraded():
-	set_draft_points( draft_points - 1)
+	set_draft_points( draft_points - 1 )
 
 func attribute_downgraded():
-	set_draft_points( draft_points + 1)
+	set_draft_points( draft_points + 1 )
 
 func set_draft_points(points: int):
 	draft_points = points
+	emit_correct_signal()
+	update_points_label()
+	disable_confirm_if_no_action_taken()
+
+func emit_correct_signal():
 	if (draft_points == 0):
 		emit_signal("attribute_points_depleted")
 	elif (draft_points > 0):
 		emit_signal("attribute_points_available")
-	update_points_label()
-	
+
 func update_points_label():
 	points_label.text = "Available attribute points: "
-	points_label.text += str(draft_points)
+	points_label.text += str( draft_points )
+
+func disable_confirm_if_no_action_taken():
+	var action_taken := draft_points != character.available_attribute_points
+	confirm_button.disabled = not action_taken
 
 func spawn_entries_for_attributes():
 	for attribute in StatTypes.new().attributes():
@@ -47,5 +62,5 @@ func spawn_entries_for_attributes():
 			attribute, character_changed, attribute_points_depleted, attribute_points_available)
 		entry.attribute_upgraded.connect( attribute_upgraded )
 		entry.attribute_downgraded.connect( attribute_downgraded )
-		entries.append(entry)
-		container.add_child(entry)
+		entry.add_to_group(attributes_group_name)
+		container.add_child( entry )

--- a/Scripts/UI/Skill/AttributesMenu.gd
+++ b/Scripts/UI/Skill/AttributesMenu.gd
@@ -4,8 +4,13 @@ class_name AttributesMenu extends Node
 @export var container: VBoxContainer
 @export var menu_entry_template: PackedScene
 
+signal attribute_points_depleted
+signal attribute_points_available
+
 var character: PlayerCombatant
 var entries: Array[AttributeMenuEntry]
+var draft_points: int = 0
+
 var character_changed: Signal
 
 func initialize(_character_changed: Signal):
@@ -15,15 +20,32 @@ func initialize(_character_changed: Signal):
 	
 func update_and_render(_character: PlayerCombatant):
 	character = _character
-	render()
+	set_draft_points( character.available_attribute_points )
 
-func render():
+func attribute_upgraded():
+	set_draft_points( draft_points - 1)
+
+func attribute_downgraded():
+	set_draft_points( draft_points + 1)
+
+func set_draft_points(points: int):
+	draft_points = points
+	if (draft_points == 0):
+		emit_signal("attribute_points_depleted")
+	elif (draft_points > 0):
+		emit_signal("attribute_points_available")
+	update_points_label()
+	
+func update_points_label():
 	points_label.text = "Available attribute points: "
-	points_label.text += str(character.available_attribute_points)
+	points_label.text += str(draft_points)
 
 func spawn_entries_for_attributes():
 	for attribute in StatTypes.new().attributes():
-		var entry := menu_entry_template.instantiate()
-		entry.initialize(attribute, character_changed)
+		var entry := menu_entry_template.instantiate() as AttributeMenuEntry
+		entry.initialize(
+			attribute, character_changed, attribute_points_depleted, attribute_points_available)
+		entry.attribute_upgraded.connect( attribute_upgraded )
+		entry.attribute_downgraded.connect( attribute_downgraded )
 		entries.append(entry)
 		container.add_child(entry)

--- a/Scripts/UI/Skill/AttributesMenu.gd
+++ b/Scripts/UI/Skill/AttributesMenu.gd
@@ -59,7 +59,7 @@ func spawn_entries_for_attributes():
 	for attribute in StatTypes.new().attributes():
 		var entry := menu_entry_template.instantiate() as AttributeMenuEntry
 		entry.initialize(
-			attribute, character_changed, attribute_points_depleted, attribute_points_available)
+			attribute, character_changed, attribute_points_depleted, attribute_points_available )
 		entry.attribute_upgraded.connect( attribute_upgraded )
 		entry.attribute_downgraded.connect( attribute_downgraded )
 		entry.add_to_group( attributes_group_name )

--- a/Scripts/UI/Skill/AttributesMenu.gd
+++ b/Scripts/UI/Skill/AttributesMenu.gd
@@ -11,16 +11,19 @@ var character_changed: Signal
 func initialize(_character_changed: Signal):
 	character_changed = _character_changed
 	character_changed.connect( update_and_render )
+	spawn_entries_for_attributes()
+	
+func update_and_render(_character: PlayerCombatant):
+	character = _character
+	render()
+
+func render():
+	points_label.text = "Available attribute points: "
+	points_label.text += str(character.available_attribute_points)
+
+func spawn_entries_for_attributes():
 	for attribute in StatTypes.new().attributes():
 		var entry := menu_entry_template.instantiate()
 		entry.initialize(attribute, character_changed)
 		entries.append(entry)
 		container.add_child(entry)
-	
-func update_and_render(_character: PlayerCombatant):
-	character = _character
-	print("AttributesMenu: ", character.char_name)
-	render()
-
-func render():
-	pass

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -7,8 +7,10 @@ class_name SkillMenu extends Control
 @export var skill_points_label: Label
 @export var canvas: CanvasLayer
 @export var skills_tree_renderer: SkillsTreeRenderer
+@export var attributes_menu: AttributesMenu
 
 signal skill_points_depleted
+signal character_changed(character: PlayerCombatant)
 
 var characters:= PlayerPartyController.party_members
 var current_character: PlayerCombatant
@@ -22,6 +24,7 @@ func _ready():
 	confirm_button.button_down.connect( confirm_points )
 	undo_skill_points_button.button_down.connect( undo_points )
 	skills_tree_renderer.initialize( on_skill_upgraded, skill_points_depleted )
+	attributes_menu.initialize(character_changed)
 
 func add_tabs_per_character():
 	tab_bar.clear_tabs()
@@ -36,6 +39,7 @@ func on_visibility_changed():
 func render_tab(index: int):
 	if (PlayerPartyController.has_members()):
 		current_character = characters[index]
+		emit_signal("character_changed", current_character)
 		skills_tree_renderer.start(current_character.skill_holder.skills())
 		set_draft_skill_points( current_character.available_skill_points )
 


### PR DESCRIPTION
## Changes
* Added `AttributesMenu` to show available points, attribute points, and where points can be spent
* Same as `SkillsMenu`: we can assign points, undo, and confirm.

Added some test code to check, also changed the increase amount per attribute to check that it increased correctly.
![Animation](https://github.com/EveningComet/Project-Horizon/assets/33893929/cd6e89de-b54f-402a-bc6d-c50edc779811)
