### PR TITLE
[SkillsMenu] Add boost class level

### DIFF
--- a/Scenes/UI/Skill/Attribute Menu Entry.tscn
+++ b/Scenes/UI/Skill/Attribute Menu Entry.tscn
@@ -2,11 +2,10 @@
 
 [ext_resource type="Script" path="res://Scripts/UI/Skill/AttributeMenuEntry.gd" id="1_ey26o"]
 
-[node name="AttributeMenuEntry" type="HBoxContainer" node_paths=PackedStringArray("attribute_label", "upgrade_button", "downgrade_button")]
+[node name="AttributeMenuEntry" type="HBoxContainer" node_paths=PackedStringArray("attribute_label", "upgrade_button")]
 script = ExtResource("1_ey26o")
 attribute_label = NodePath("AttributeLabel")
 upgrade_button = NodePath("UpgradeButton")
-downgrade_button = NodePath("DowngradeButton")
 
 [node name="AttributeLabel" type="Label" parent="."]
 layout_mode = 2
@@ -21,8 +20,3 @@ theme_override_constants/margin_bottom = 5
 custom_minimum_size = Vector2(25, 0)
 layout_mode = 2
 text = "+"
-
-[node name="DowngradeButton" type="Button" parent="."]
-custom_minimum_size = Vector2(25, 0)
-layout_mode = 2
-text = "-"

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -41,7 +41,7 @@ script = ExtResource("7_ufqe0")
 [node name="AttributesMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("points_label", "confirm_button", "container", "upgrader")]
 script = ExtResource("4_k8sm6")
 points_label = NodePath("../OverviewPanel/AttributesPanel/AttributePointsLabel")
-confirm_button = NodePath("../OverviewPanel/AttributesPanel/ConfirmButton")
+confirm_button = NodePath("../OverviewPanel/SkillsPanel/ConfirmButton")
 container = NodePath("../OverviewPanel/AttributesPanel/AttributesContainer")
 menu_entry_template = ExtResource("5_b7hp3")
 upgrader = NodePath("../AttributesUpgrader")
@@ -73,7 +73,7 @@ layout_mode = 0
 offset_left = 33.0
 offset_top = 35.0
 offset_right = 1137.0
-offset_bottom = 731.0
+offset_bottom = 683.0
 
 [node name="AttributesHeaderLabel" type="Label" parent="SkillMenu/OverviewPanel/SkillsPanel"]
 layout_mode = 0
@@ -119,35 +119,36 @@ text = "No members recruited"
 [node name="ClassInfoContainer" type="VBoxContainer" parent="SkillMenu/OverviewPanel/SkillsPanel"]
 layout_mode = 0
 offset_left = 48.0
-offset_top = 544.0
+offset_top = 528.0
 offset_right = 272.0
-offset_bottom = 648.0
+offset_bottom = 632.0
 
 [node name="ClassUpgradeButton" type="Button" parent="SkillMenu/OverviewPanel/SkillsPanel"]
 layout_mode = 0
-offset_left = 272.0
-offset_top = 608.0
-offset_right = 384.0
-offset_bottom = 656.0
+offset_left = 280.0
+offset_top = 560.0
+offset_right = 392.0
+offset_bottom = 608.0
+disabled = true
 text = "Upgrade"
 
 [node name="ConfirmButton" type="Button" parent="SkillMenu/OverviewPanel/SkillsPanel"]
 custom_minimum_size = Vector2(200, 50)
 layout_mode = 0
-offset_left = 664.0
-offset_top = 608.0
-offset_right = 864.0
-offset_bottom = 658.0
+offset_left = 1144.0
+offset_top = 320.0
+offset_right = 1424.0
+offset_bottom = 370.0
 disabled = true
 text = "Confirm"
 
 [node name="UndoSkillPointsButton" type="Button" parent="SkillMenu/OverviewPanel/SkillsPanel"]
 custom_minimum_size = Vector2(200, 50)
 layout_mode = 0
-offset_left = 872.0
-offset_top = 608.0
-offset_right = 1072.0
-offset_bottom = 658.0
+offset_left = 1144.0
+offset_top = 384.0
+offset_right = 1424.0
+offset_bottom = 434.0
 disabled = true
 text = "Undo points"
 
@@ -181,16 +182,6 @@ offset_left = 32.0
 offset_top = 88.0
 offset_right = 72.0
 offset_bottom = 128.0
-
-[node name="ConfirmButton" type="Button" parent="SkillMenu/OverviewPanel/AttributesPanel"]
-custom_minimum_size = Vector2(200, 50)
-layout_mode = 0
-offset_left = 40.0
-offset_top = 232.0
-offset_right = 240.0
-offset_bottom = 282.0
-disabled = true
-text = "Confirm"
 
 [node name="ExitButton" type="Button" parent="SkillMenu"]
 custom_minimum_size = Vector2(50, 0)

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -46,10 +46,11 @@ container = NodePath("../OverviewPanel/AttributesPanel/AttributesContainer")
 menu_entry_template = ExtResource("5_b7hp3")
 upgrader = NodePath("../AttributesUpgrader")
 
-[node name="ClassUpgradeMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("info_container", "upgrade_button")]
+[node name="ClassUpgradeMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("info_container", "upgrade_button", "upgrader")]
 script = ExtResource("6_j0n5l")
 info_container = NodePath("../OverviewPanel/SkillsPanel/ClassInfoContainer")
 upgrade_button = NodePath("../OverviewPanel/SkillsPanel/ClassUpgradeButton")
+upgrader = NodePath("../AttributesUpgrader")
 
 [node name="TabBar" type="TabBar" parent="SkillMenu"]
 layout_mode = 0
@@ -126,7 +127,7 @@ offset_bottom = 648.0
 layout_mode = 0
 offset_left = 272.0
 offset_top = 608.0
-offset_right = 368.0
+offset_right = 384.0
 offset_bottom = 656.0
 text = "Upgrade"
 

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -38,13 +38,13 @@ wait_skills_render_timer = NodePath("../../WaitSkillsRenderTimer")
 [node name="AttributesUpgrader" type="Node" parent="SkillMenu"]
 script = ExtResource("7_ufqe0")
 
-[node name="AttributesMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("points_label", "confirm_button", "container", "upgrader")]
+[node name="AttributesMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("points_label", "container", "upgrader", "confirm_button")]
 script = ExtResource("4_k8sm6")
 points_label = NodePath("../OverviewPanel/AttributesPanel/AttributePointsLabel")
-confirm_button = NodePath("../OverviewPanel/SkillsPanel/ConfirmButton")
 container = NodePath("../OverviewPanel/AttributesPanel/AttributesContainer")
 menu_entry_template = ExtResource("5_b7hp3")
 upgrader = NodePath("../AttributesUpgrader")
+confirm_button = NodePath("../OverviewPanel/SkillsPanel/ConfirmButton")
 
 [node name="ClassUpgradeMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("info_container", "upgrade_button", "upgrader")]
 script = ExtResource("6_j0n5l")

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -21,7 +21,7 @@ script = ExtResource("1_gb7ft")
 tab_bar = NodePath("TabBar")
 exit_button = NodePath("ExitButton")
 confirm_button = NodePath("OverviewPanel/SkillsPanel/ConfirmButton")
-undo_skill_points_button = NodePath("OverviewPanel/SkillsPanel/UndoSkillPointsButton")
+undo_skill_points_button = NodePath("OverviewPanel/SkillsPanel/UndoButton")
 skill_points_label = NodePath("OverviewPanel/SkillsPanel/SkillPointsLabel")
 canvas = NodePath("..")
 skills_tree_renderer = NodePath("SkillsTreeRenderer")
@@ -38,13 +38,14 @@ wait_skills_render_timer = NodePath("../../WaitSkillsRenderTimer")
 [node name="AttributesUpgrader" type="Node" parent="SkillMenu"]
 script = ExtResource("7_ufqe0")
 
-[node name="AttributesMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("points_label", "container", "upgrader", "confirm_button")]
+[node name="AttributesMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("points_label", "container", "upgrader", "confirm_button", "undo_button")]
 script = ExtResource("4_k8sm6")
 points_label = NodePath("../OverviewPanel/AttributesPanel/AttributePointsLabel")
 container = NodePath("../OverviewPanel/AttributesPanel/AttributesContainer")
 menu_entry_template = ExtResource("5_b7hp3")
 upgrader = NodePath("../AttributesUpgrader")
 confirm_button = NodePath("../OverviewPanel/SkillsPanel/ConfirmButton")
+undo_button = NodePath("../OverviewPanel/SkillsPanel/UndoButton")
 
 [node name="ClassUpgradeMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("info_container", "upgrade_button", "upgrader")]
 script = ExtResource("6_j0n5l")
@@ -142,7 +143,7 @@ offset_bottom = 370.0
 disabled = true
 text = "Confirm"
 
-[node name="UndoSkillPointsButton" type="Button" parent="SkillMenu/OverviewPanel/SkillsPanel"]
+[node name="UndoButton" type="Button" parent="SkillMenu/OverviewPanel/SkillsPanel"]
 custom_minimum_size = Vector2(200, 50)
 layout_mode = 0
 offset_left = 1144.0

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -1,14 +1,15 @@
-[gd_scene load_steps=6 format=3 uid="uid://dks4qxa6s4ful"]
+[gd_scene load_steps=7 format=3 uid="uid://dks4qxa6s4ful"]
 
 [ext_resource type="Script" path="res://Scripts/UI/Skill/SkillMenu.gd" id="1_gb7ft"]
 [ext_resource type="PackedScene" uid="uid://bngujmgvwnby5" path="res://Scenes/UI/Skill/Skill Menu Button.tscn" id="2_44m12"]
 [ext_resource type="Script" path="res://Scripts/UI/Skill/SkillsTreeRenderer.gd" id="3_3kt4c"]
 [ext_resource type="Script" path="res://Scripts/UI/Skill/AttributesMenu.gd" id="4_k8sm6"]
-[ext_resource type="PackedScene" uid="uid://dq83dljr1ulfa" path="res://Scenes/UI/Skill/Attribute Menu Entry.tscn" id="5_b7hp3"]
+[ext_resource type="PackedScene" path="res://Scenes/UI/Skill/Attribute Menu Entry.tscn" id="5_b7hp3"]
+[ext_resource type="Script" path="res://Scripts/UI/Skill/ClassUpgradeMenu.gd" id="6_j0n5l"]
 
 [node name="SkillMenu" type="CanvasLayer"]
 
-[node name="SkillMenu" type="Control" parent="." node_paths=PackedStringArray("tab_bar", "exit_button", "confirm_button", "undo_skill_points_button", "skill_points_label", "canvas", "skills_tree_renderer", "attributes_menu")]
+[node name="SkillMenu" type="Control" parent="." node_paths=PackedStringArray("tab_bar", "exit_button", "confirm_button", "undo_skill_points_button", "skill_points_label", "canvas", "skills_tree_renderer", "attributes_menu", "class_upgrade_menu")]
 layout_mode = 3
 anchors_preset = 0
 offset_left = 399.0
@@ -18,25 +19,31 @@ offset_bottom = 253.0
 script = ExtResource("1_gb7ft")
 tab_bar = NodePath("TabBar")
 exit_button = NodePath("ExitButton")
-confirm_button = NodePath("SkillPanel/ConfirmButton")
-undo_skill_points_button = NodePath("SkillPanel/UndoSkillPointsButton")
-skill_points_label = NodePath("SkillPanel/SkillPointsLabel")
+confirm_button = NodePath("OverviewPanel/SkillsPanel/ConfirmButton")
+undo_skill_points_button = NodePath("OverviewPanel/SkillsPanel/UndoSkillPointsButton")
+skill_points_label = NodePath("OverviewPanel/SkillsPanel/SkillPointsLabel")
 canvas = NodePath("..")
 skills_tree_renderer = NodePath("SkillsTreeRenderer")
 attributes_menu = NodePath("AttributesMenu")
+class_upgrade_menu = NodePath("ClassUpgradeMenu")
 
 [node name="SkillsTreeRenderer" type="Node" parent="SkillMenu" node_paths=PackedStringArray("skill_container", "wait_skills_render_timer")]
 script = ExtResource("3_3kt4c")
-skill_container = NodePath("../SkillPanel/ScrollContainer/VBoxContainer/MarginContainer/HBoxContainer")
+skill_container = NodePath("../OverviewPanel/SkillsPanel/SkillsContainer/VBoxContainer/MarginContainer/HBoxContainer")
 skill_menu_button_template = ExtResource("2_44m12")
 wait_skills_render_timer = NodePath("../../WaitSkillsRenderTimer")
 
 [node name="AttributesMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("points_label", "confirm_button", "container")]
 script = ExtResource("4_k8sm6")
-points_label = NodePath("../SkillPanel/AttributesPanel/AttributePointsLabel")
-confirm_button = NodePath("../SkillPanel/AttributesPanel/ConfirmButton")
-container = NodePath("../SkillPanel/AttributesPanel/AttributesContainer")
+points_label = NodePath("../OverviewPanel/AttributesPanel/AttributePointsLabel")
+confirm_button = NodePath("../OverviewPanel/AttributesPanel/ConfirmButton")
+container = NodePath("../OverviewPanel/AttributesPanel/AttributesContainer")
 menu_entry_template = ExtResource("5_b7hp3")
+
+[node name="ClassUpgradeMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("info_container", "upgrade_button")]
+script = ExtResource("6_j0n5l")
+info_container = NodePath("../OverviewPanel/SkillsPanel/ClassInfoContainer")
+upgrade_button = NodePath("../OverviewPanel/SkillsPanel/ClassUpgradeButton")
 
 [node name="TabBar" type="TabBar" parent="SkillMenu"]
 layout_mode = 0
@@ -47,71 +54,110 @@ clip_tabs = false
 tab_0/title = "Character 1"
 tab_1/title = "Character 2"
 
-[node name="SkillPanel" type="Panel" parent="SkillMenu"]
+[node name="OverviewPanel" type="Panel" parent="SkillMenu"]
 custom_minimum_size = Vector2(1500, 800)
 layout_mode = 0
 offset_top = 40.0
 offset_right = 40.0
 offset_bottom = 80.0
 
-[node name="ScrollContainer" type="ScrollContainer" parent="SkillMenu/SkillPanel"]
+[node name="SkillsPanel" type="Panel" parent="SkillMenu/OverviewPanel"]
 layout_mode = 0
-offset_right = 1073.0
-offset_bottom = 675.0
+offset_left = 33.0
+offset_top = 35.0
+offset_right = 1137.0
+offset_bottom = 731.0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="SkillMenu/SkillPanel/ScrollContainer"]
+[node name="AttributesHeaderLabel" type="Label" parent="SkillMenu/OverviewPanel/SkillsPanel"]
+offset_left = 24.0
+offset_top = 24.0
+offset_right = 118.0
+offset_bottom = 47.0
+text = "SKILLS & CLASS LEVELS"
+uppercase = true
+
+[node name="SkillPointsLabel" type="Label" parent="SkillMenu/OverviewPanel/SkillsPanel"]
+layout_mode = 0
+offset_left = 24.0
+offset_top = 56.0
+offset_right = 211.0
+offset_bottom = 79.0
+text = "No available skills point"
+
+[node name="SkillsContainer" type="ScrollContainer" parent="SkillMenu/OverviewPanel/SkillsPanel"]
+layout_mode = 0
+offset_left = 24.0
+offset_top = 88.0
+offset_right = 1040.0
+offset_bottom = 528.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="SkillMenu/OverviewPanel/SkillsPanel/SkillsContainer"]
 layout_mode = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="SkillMenu/SkillPanel/ScrollContainer/VBoxContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="SkillMenu/OverviewPanel/SkillsPanel/SkillsContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_constants/margin_left = 15
 theme_override_constants/margin_top = 15
 theme_override_constants/margin_right = 15
 theme_override_constants/margin_bottom = 15
 
-[node name="HBoxContainer" type="HBoxContainer" parent="SkillMenu/SkillPanel/ScrollContainer/VBoxContainer/MarginContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="SkillMenu/OverviewPanel/SkillsPanel/SkillsContainer/VBoxContainer/MarginContainer"]
 layout_mode = 2
 
-[node name="PartyEmptyLabel" type="Label" parent="SkillMenu/SkillPanel/ScrollContainer/VBoxContainer/MarginContainer/HBoxContainer"]
+[node name="PartyEmptyLabel" type="Label" parent="SkillMenu/OverviewPanel/SkillsPanel/SkillsContainer/VBoxContainer/MarginContainer/HBoxContainer"]
 layout_mode = 2
 text = "No members recruited"
 
-[node name="SkillPointsLabel" type="Label" parent="SkillMenu/SkillPanel"]
-layout_mode = 0
-offset_left = 25.0
-offset_top = 723.0
-offset_right = 212.0
-offset_bottom = 746.0
-text = "No available skills point"
+[node name="ClassInfoContainer" type="VBoxContainer" parent="SkillMenu/OverviewPanel/SkillsPanel"]
+offset_left = 48.0
+offset_top = 544.0
+offset_right = 272.0
+offset_bottom = 648.0
 
-[node name="ConfirmButton" type="Button" parent="SkillMenu/SkillPanel"]
+[node name="ClassUpgradeButton" type="Button" parent="SkillMenu/OverviewPanel/SkillsPanel"]
+offset_left = 272.0
+offset_top = 552.0
+offset_right = 368.0
+offset_bottom = 600.0
+disabled = true
+text = "Upgrade"
+
+[node name="ClassUpgradeButton2" type="Button" parent="SkillMenu/OverviewPanel/SkillsPanel"]
+offset_left = 272.0
+offset_top = 608.0
+offset_right = 370.0
+offset_bottom = 656.0
+disabled = true
+text = "Downgrade"
+
+[node name="ConfirmButton" type="Button" parent="SkillMenu/OverviewPanel/SkillsPanel"]
 custom_minimum_size = Vector2(200, 50)
 layout_mode = 0
-offset_left = 673.0
-offset_top = 707.0
-offset_right = 873.0
-offset_bottom = 757.0
+offset_left = 664.0
+offset_top = 608.0
+offset_right = 864.0
+offset_bottom = 658.0
 disabled = true
 text = "Confirm"
 
-[node name="UndoSkillPointsButton" type="Button" parent="SkillMenu/SkillPanel"]
+[node name="UndoSkillPointsButton" type="Button" parent="SkillMenu/OverviewPanel/SkillsPanel"]
 custom_minimum_size = Vector2(200, 50)
 layout_mode = 0
-offset_left = 873.0
-offset_top = 707.0
-offset_right = 1073.0
-offset_bottom = 757.0
+offset_left = 872.0
+offset_top = 608.0
+offset_right = 1072.0
+offset_bottom = 658.0
 disabled = true
 text = "Undo points"
 
-[node name="AttributesPanel" type="Panel" parent="SkillMenu/SkillPanel"]
+[node name="AttributesPanel" type="Panel" parent="SkillMenu/OverviewPanel"]
 layout_mode = 0
-offset_left = 1137.0
-offset_top = 67.0
-offset_right = 1417.0
-offset_bottom = 358.0
+offset_left = 1177.0
+offset_top = 43.0
+offset_right = 1457.0
+offset_bottom = 334.0
 
-[node name="AttributesHeaderLabel" type="Label" parent="SkillMenu/SkillPanel/AttributesPanel"]
+[node name="AttributesHeaderLabel" type="Label" parent="SkillMenu/OverviewPanel/AttributesPanel"]
 layout_mode = 0
 offset_left = 24.0
 offset_top = 24.0
@@ -120,7 +166,7 @@ offset_bottom = 47.0
 text = "Attributes"
 uppercase = true
 
-[node name="AttributePointsLabel" type="Label" parent="SkillMenu/SkillPanel/AttributesPanel"]
+[node name="AttributePointsLabel" type="Label" parent="SkillMenu/OverviewPanel/AttributesPanel"]
 layout_mode = 0
 offset_left = 24.0
 offset_top = 48.0
@@ -128,14 +174,14 @@ offset_right = 187.0
 offset_bottom = 71.0
 text = "Available attribute points: 0"
 
-[node name="AttributesContainer" type="VBoxContainer" parent="SkillMenu/SkillPanel/AttributesPanel"]
+[node name="AttributesContainer" type="VBoxContainer" parent="SkillMenu/OverviewPanel/AttributesPanel"]
 layout_mode = 0
 offset_left = 32.0
 offset_top = 88.0
 offset_right = 72.0
 offset_bottom = 128.0
 
-[node name="ConfirmButton" type="Button" parent="SkillMenu/SkillPanel/AttributesPanel"]
+[node name="ConfirmButton" type="Button" parent="SkillMenu/OverviewPanel/AttributesPanel"]
 custom_minimum_size = Vector2(200, 50)
 layout_mode = 0
 offset_left = 40.0

--- a/Scenes/UI/Skill/Skill Menu.tscn
+++ b/Scenes/UI/Skill/Skill Menu.tscn
@@ -1,15 +1,16 @@
-[gd_scene load_steps=7 format=3 uid="uid://dks4qxa6s4ful"]
+[gd_scene load_steps=8 format=3 uid="uid://dks4qxa6s4ful"]
 
 [ext_resource type="Script" path="res://Scripts/UI/Skill/SkillMenu.gd" id="1_gb7ft"]
 [ext_resource type="PackedScene" uid="uid://bngujmgvwnby5" path="res://Scenes/UI/Skill/Skill Menu Button.tscn" id="2_44m12"]
 [ext_resource type="Script" path="res://Scripts/UI/Skill/SkillsTreeRenderer.gd" id="3_3kt4c"]
 [ext_resource type="Script" path="res://Scripts/UI/Skill/AttributesMenu.gd" id="4_k8sm6"]
-[ext_resource type="PackedScene" path="res://Scenes/UI/Skill/Attribute Menu Entry.tscn" id="5_b7hp3"]
+[ext_resource type="PackedScene" uid="uid://dq83dljr1ulfa" path="res://Scenes/UI/Skill/Attribute Menu Entry.tscn" id="5_b7hp3"]
 [ext_resource type="Script" path="res://Scripts/UI/Skill/ClassUpgradeMenu.gd" id="6_j0n5l"]
+[ext_resource type="Script" path="res://Scripts/UI/Skill/AttributesUpgrader.gd" id="7_ufqe0"]
 
 [node name="SkillMenu" type="CanvasLayer"]
 
-[node name="SkillMenu" type="Control" parent="." node_paths=PackedStringArray("tab_bar", "exit_button", "confirm_button", "undo_skill_points_button", "skill_points_label", "canvas", "skills_tree_renderer", "attributes_menu", "class_upgrade_menu")]
+[node name="SkillMenu" type="Control" parent="." node_paths=PackedStringArray("tab_bar", "exit_button", "confirm_button", "undo_skill_points_button", "skill_points_label", "canvas", "skills_tree_renderer", "attributes_menu", "class_upgrade_menu", "attributes_upgrader")]
 layout_mode = 3
 anchors_preset = 0
 offset_left = 399.0
@@ -26,6 +27,7 @@ canvas = NodePath("..")
 skills_tree_renderer = NodePath("SkillsTreeRenderer")
 attributes_menu = NodePath("AttributesMenu")
 class_upgrade_menu = NodePath("ClassUpgradeMenu")
+attributes_upgrader = NodePath("AttributesUpgrader")
 
 [node name="SkillsTreeRenderer" type="Node" parent="SkillMenu" node_paths=PackedStringArray("skill_container", "wait_skills_render_timer")]
 script = ExtResource("3_3kt4c")
@@ -33,12 +35,16 @@ skill_container = NodePath("../OverviewPanel/SkillsPanel/SkillsContainer/VBoxCon
 skill_menu_button_template = ExtResource("2_44m12")
 wait_skills_render_timer = NodePath("../../WaitSkillsRenderTimer")
 
-[node name="AttributesMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("points_label", "confirm_button", "container")]
+[node name="AttributesUpgrader" type="Node" parent="SkillMenu"]
+script = ExtResource("7_ufqe0")
+
+[node name="AttributesMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("points_label", "confirm_button", "container", "upgrader")]
 script = ExtResource("4_k8sm6")
 points_label = NodePath("../OverviewPanel/AttributesPanel/AttributePointsLabel")
 confirm_button = NodePath("../OverviewPanel/AttributesPanel/ConfirmButton")
 container = NodePath("../OverviewPanel/AttributesPanel/AttributesContainer")
 menu_entry_template = ExtResource("5_b7hp3")
+upgrader = NodePath("../AttributesUpgrader")
 
 [node name="ClassUpgradeMenu" type="Node" parent="SkillMenu" node_paths=PackedStringArray("info_container", "upgrade_button")]
 script = ExtResource("6_j0n5l")
@@ -69,6 +75,7 @@ offset_right = 1137.0
 offset_bottom = 731.0
 
 [node name="AttributesHeaderLabel" type="Label" parent="SkillMenu/OverviewPanel/SkillsPanel"]
+layout_mode = 0
 offset_left = 24.0
 offset_top = 24.0
 offset_right = 118.0
@@ -109,26 +116,19 @@ layout_mode = 2
 text = "No members recruited"
 
 [node name="ClassInfoContainer" type="VBoxContainer" parent="SkillMenu/OverviewPanel/SkillsPanel"]
+layout_mode = 0
 offset_left = 48.0
 offset_top = 544.0
 offset_right = 272.0
 offset_bottom = 648.0
 
 [node name="ClassUpgradeButton" type="Button" parent="SkillMenu/OverviewPanel/SkillsPanel"]
-offset_left = 272.0
-offset_top = 552.0
-offset_right = 368.0
-offset_bottom = 600.0
-disabled = true
-text = "Upgrade"
-
-[node name="ClassUpgradeButton2" type="Button" parent="SkillMenu/OverviewPanel/SkillsPanel"]
+layout_mode = 0
 offset_left = 272.0
 offset_top = 608.0
-offset_right = 370.0
+offset_right = 368.0
 offset_bottom = 656.0
-disabled = true
-text = "Downgrade"
+text = "Upgrade"
 
 [node name="ConfirmButton" type="Button" parent="SkillMenu/OverviewPanel/SkillsPanel"]
 custom_minimum_size = Vector2(200, 50)

--- a/Scripts/UI/Skill/AttributeMenuEntry.gd
+++ b/Scripts/UI/Skill/AttributeMenuEntry.gd
@@ -24,8 +24,8 @@ func initialize(
 	downgrade_button.button_down.connect( downgrade )
 
 func update_and_render(stats: Dictionary):
-	update_label(stats[attribute])
-	downgrade_button.disabled = !upgrader.can_do_attribute_downgrade(attribute)
+	update_label( stats[attribute] )
+	downgrade_button.disabled = !upgrader.can_do_attribute_downgrade( attribute )
 
 func disable_upgrade():
 	upgrade_button.disabled = true
@@ -34,11 +34,11 @@ func enable_upgrade():
 	upgrade_button.disabled = false
 
 func upgrade():
-	upgrader.attribute_upgrade(attribute)
+	upgrader.attribute_upgrade( attribute )
 	emit_signal( "attribute_upgraded" )
 
 func downgrade():
-	upgrader.attribute_downgrade(attribute)
+	upgrader.attribute_downgrade( attribute )
 	emit_signal( "attribute_downgraded" )
 
 func confirm():

--- a/Scripts/UI/Skill/AttributeMenuEntry.gd
+++ b/Scripts/UI/Skill/AttributeMenuEntry.gd
@@ -18,7 +18,6 @@ func initialize(
 	attribute = _attribute
 	upgrader = _upgrader
 	upgrader.stats_changed.connect( update_and_render )
-	upgrader.stats_confirmed.connect( update_and_render )
 	_points_depleted.connect( disable_upgrade )
 	_points_available.connect( enable_upgrade )
 	upgrade_button.button_down.connect( upgrade )
@@ -26,7 +25,7 @@ func initialize(
 
 func update_and_render(stats: Dictionary):
 	update_label(stats[attribute])
-	downgrade_button.disabled = upgrader.is_minimum_reached(attribute)
+	downgrade_button.disabled = !upgrader.can_do_attribute_downgrade(attribute)
 
 func disable_upgrade():
 	upgrade_button.disabled = true
@@ -35,11 +34,11 @@ func enable_upgrade():
 	upgrade_button.disabled = false
 
 func upgrade():
-	upgrader.upgrade(attribute)
+	upgrader.attribute_upgrade(attribute)
 	emit_signal( "attribute_upgraded" )
 
 func downgrade():
-	upgrader.downgrade(attribute)
+	upgrader.attribute_downgrade(attribute)
 	emit_signal( "attribute_downgraded" )
 
 func confirm():

--- a/Scripts/UI/Skill/AttributeMenuEntry.gd
+++ b/Scripts/UI/Skill/AttributeMenuEntry.gd
@@ -9,24 +9,24 @@ signal attribute_downgraded
 
 var stat_types := StatTypes.new()
 var attribute: StatTypes.stat_types
-
-var stat: Stat
-var draft_points: int = 0
+var upgrader: AttributesUpgrader
 
 func initialize(
-	_attribute: StatTypes.stat_types,
-	_character_changed: Signal, _points_depleted: Signal, _points_available: Signal):
+	_attribute: StatTypes.stat_types, _upgrader: AttributesUpgrader,
+	_points_depleted: Signal, _points_available: Signal):
 	
 	attribute = _attribute
-	_character_changed.connect( update_and_render )
+	upgrader = _upgrader
+	upgrader.stats_changed.connect( update_and_render )
+	upgrader.stats_confirmed.connect( update_and_render )
 	_points_depleted.connect( disable_upgrade )
 	_points_available.connect( enable_upgrade )
 	upgrade_button.button_down.connect( upgrade )
 	downgrade_button.button_down.connect( downgrade )
 
-func update_and_render(character: PlayerCombatant):
-	stat = character.stats[attribute]
-	set_draft_points( stat.get_base_value() )
+func update_and_render(stats: Dictionary):
+	update_label(stats[attribute])
+	downgrade_button.disabled = upgrader.is_minimum_reached(attribute)
 
 func disable_upgrade():
 	upgrade_button.disabled = true
@@ -35,31 +35,17 @@ func enable_upgrade():
 	upgrade_button.disabled = false
 
 func upgrade():
-	set_draft_points ( draft_points + 1 )
+	upgrader.upgrade(attribute)
 	emit_signal( "attribute_upgraded" )
 
 func downgrade():
-	var is_at_minimum := draft_points == stat.get_base_value()
-	if (not is_at_minimum):
-		set_draft_points ( draft_points - 1 )
-		emit_signal( "attribute_downgraded" )
-
-func set_draft_points(points: int):
-	draft_points = points
-	update_label()
-	disable_downgrade_if_minimum_reached()
+	upgrader.downgrade(attribute)
+	emit_signal( "attribute_downgraded" )
 
 func confirm():
-	stat.set_base_value( draft_points )
-	set_draft_points( stat.get_base_value() )
+	upgrader.confirm()
 
-func refresh():
-	set_draft_points( stat.get_base_value() )
-	
-func disable_downgrade_if_minimum_reached():
-	downgrade_button.disabled = draft_points <= stat.get_base_value()
-
-func update_label():
+func update_label(points: int):
 	attribute_label.text = stat_types.stat_types_to_string[attribute]
 	attribute_label.text += ": "
-	attribute_label.text += str( draft_points )
+	attribute_label.text += str( points )

--- a/Scripts/UI/Skill/AttributeMenuEntry.gd
+++ b/Scripts/UI/Skill/AttributeMenuEntry.gd
@@ -12,7 +12,6 @@ var attribute: StatTypes.stat_types
 
 var stat: Stat
 var draft_points: int = 0
-var increase_amount: int = 0
 
 func initialize(
 	_attribute: StatTypes.stat_types,
@@ -28,7 +27,6 @@ func initialize(
 func update_and_render(character: PlayerCombatant):
 	stat = character.stats[attribute]
 	draft_points = character.stats[attribute].get_base_value()
-	increase_amount = character.get_attributes_increase()[attribute]
 	set_draft_points( stat.get_base_value() )
 
 func disable_upgrade():
@@ -38,13 +36,13 @@ func enable_upgrade():
 	upgrade_button.disabled = false
 
 func upgrade():
-	set_draft_points ( draft_points + increase_amount )
+	set_draft_points ( draft_points + 1 )
 	emit_signal( "attribute_upgraded" )
 
 func downgrade():
 	var is_at_minimum := draft_points == stat.get_base_value()
 	if (not is_at_minimum):
-		set_draft_points ( draft_points - increase_amount )
+		set_draft_points ( draft_points - 1 )
 		emit_signal( "attribute_downgraded" )
 
 func set_draft_points(points: int):

--- a/Scripts/UI/Skill/AttributeMenuEntry.gd
+++ b/Scripts/UI/Skill/AttributeMenuEntry.gd
@@ -2,10 +2,6 @@ class_name AttributeMenuEntry extends HBoxContainer
 
 @export var attribute_label: Label
 @export var upgrade_button: Button
-@export var downgrade_button: Button
-
-signal attribute_upgraded
-signal attribute_downgraded
 
 var stat_types := StatTypes.new()
 var attribute: StatTypes.stat_types
@@ -21,11 +17,9 @@ func initialize(
 	_points_depleted.connect( disable_upgrade )
 	_points_available.connect( enable_upgrade )
 	upgrade_button.button_down.connect( upgrade )
-	downgrade_button.button_down.connect( downgrade )
 
 func update_and_render(stats: Dictionary):
 	update_label( stats[attribute] )
-	downgrade_button.disabled = !upgrader.can_do_attribute_downgrade( attribute )
 
 func disable_upgrade():
 	upgrade_button.disabled = true
@@ -35,14 +29,6 @@ func enable_upgrade():
 
 func upgrade():
 	upgrader.attribute_upgrade( attribute )
-	emit_signal( "attribute_upgraded" )
-
-func downgrade():
-	upgrader.attribute_downgrade( attribute )
-	emit_signal( "attribute_downgraded" )
-
-func confirm():
-	upgrader.confirm()
 
 func update_label(points: int):
 	attribute_label.text = stat_types.stat_types_to_string[attribute]

--- a/Scripts/UI/Skill/AttributeMenuEntry.gd
+++ b/Scripts/UI/Skill/AttributeMenuEntry.gd
@@ -26,7 +26,6 @@ func initialize(
 
 func update_and_render(character: PlayerCombatant):
 	stat = character.stats[attribute]
-	draft_points = character.stats[attribute].get_base_value()
 	set_draft_points( stat.get_base_value() )
 
 func disable_upgrade():
@@ -52,6 +51,9 @@ func set_draft_points(points: int):
 
 func confirm():
 	stat.set_base_value( draft_points )
+	set_draft_points( stat.get_base_value() )
+
+func refresh():
 	set_draft_points( stat.get_base_value() )
 	
 func disable_downgrade_if_minimum_reached():

--- a/Scripts/UI/Skill/AttributesMenu.gd
+++ b/Scripts/UI/Skill/AttributesMenu.gd
@@ -42,9 +42,6 @@ func set_draft_points(points: int):
 	update_points_label()
 	disable_confirm_if_no_action_taken()
 
-func refresh():
-	get_tree().call_group( attributes_group_name, "refresh" )
-
 func emit_correct_signal():
 	if (draft_points == 0):
 		emit_signal( "attribute_points_depleted" )

--- a/Scripts/UI/Skill/AttributesMenu.gd
+++ b/Scripts/UI/Skill/AttributesMenu.gd
@@ -19,7 +19,7 @@ func initialize(_character_changed: Signal):
 	character_changed.connect( update_and_render )
 	confirm_button.button_down.connect( confirm )
 	spawn_entries_for_attributes()
-	
+
 func update_and_render(_character: PlayerCombatant):
 	character = _character
 	set_draft_points( character.available_attribute_points )
@@ -40,6 +40,9 @@ func set_draft_points(points: int):
 	emit_correct_signal()
 	update_points_label()
 	disable_confirm_if_no_action_taken()
+
+func refresh():
+	get_tree().call_group( attributes_group_name, "refresh" )
 
 func emit_correct_signal():
 	if (draft_points == 0):

--- a/Scripts/UI/Skill/AttributesMenu.gd
+++ b/Scripts/UI/Skill/AttributesMenu.gd
@@ -4,6 +4,7 @@ class_name AttributesMenu extends Node
 @export var confirm_button: Button
 @export var container: VBoxContainer
 @export var menu_entry_template: PackedScene
+@export var upgrader: AttributesUpgrader
 
 signal attribute_points_depleted
 signal attribute_points_available
@@ -62,7 +63,7 @@ func spawn_entries_for_attributes():
 	for attribute in StatTypes.new().attributes():
 		var entry := menu_entry_template.instantiate() as AttributeMenuEntry
 		entry.initialize(
-			attribute, character_changed, attribute_points_depleted, attribute_points_available )
+			attribute, upgrader, attribute_points_depleted, attribute_points_available )
 		entry.attribute_upgraded.connect( attribute_upgraded )
 		entry.attribute_downgraded.connect( attribute_downgraded )
 		entry.add_to_group( attributes_group_name )

--- a/Scripts/UI/Skill/AttributesMenu.gd
+++ b/Scripts/UI/Skill/AttributesMenu.gd
@@ -1,10 +1,10 @@
 class_name AttributesMenu extends Node
 
 @export var points_label: Label
-@export var confirm_button: Button
 @export var container: VBoxContainer
 @export var menu_entry_template: PackedScene
 @export var upgrader: AttributesUpgrader
+@export var confirm_button: Button
 
 signal attribute_points_depleted
 signal attribute_points_available
@@ -12,13 +12,11 @@ signal attribute_points_available
 var character: PlayerCombatant
 var draft_points: int = 0
 
-var character_changed: Signal
-const attributes_group_name := "attributes"
-
 func initialize(_character_changed: Signal):
-	character_changed = _character_changed
-	character_changed.connect( update_and_render )
-	confirm_button.button_down.connect( confirm )
+	_character_changed.connect( update_and_render )
+	upgrader.stats_confirmed.connect( confirm )
+	upgrader.stats_undone.connect( undo )
+	upgrader.attribute_upgraded.connect( attribute_upgraded )
 	spawn_entries_for_attributes()
 
 func update_and_render(_character: PlayerCombatant):
@@ -27,8 +25,9 @@ func update_and_render(_character: PlayerCombatant):
 
 func confirm():
 	character.available_attribute_points = draft_points
+
+func undo():
 	set_draft_points( character.available_attribute_points )
-	get_tree().call_group( attributes_group_name, "confirm" )
 
 func attribute_upgraded():
 	set_draft_points( draft_points - 1 )
@@ -61,7 +60,4 @@ func spawn_entries_for_attributes():
 		var entry := menu_entry_template.instantiate() as AttributeMenuEntry
 		entry.initialize(
 			attribute, upgrader, attribute_points_depleted, attribute_points_available )
-		entry.attribute_upgraded.connect( attribute_upgraded )
-		entry.attribute_downgraded.connect( attribute_downgraded )
-		entry.add_to_group( attributes_group_name )
 		container.add_child( entry )

--- a/Scripts/UI/Skill/AttributesMenu.gd
+++ b/Scripts/UI/Skill/AttributesMenu.gd
@@ -5,6 +5,7 @@ class_name AttributesMenu extends Node
 @export var menu_entry_template: PackedScene
 @export var upgrader: AttributesUpgrader
 @export var confirm_button: Button
+@export var undo_button: Button
 
 signal attribute_points_depleted
 signal attribute_points_available
@@ -25,6 +26,7 @@ func update_and_render(_character: PlayerCombatant):
 
 func confirm():
 	character.available_attribute_points = draft_points
+	set_draft_points( character.available_attribute_points )
 
 func undo():
 	set_draft_points( character.available_attribute_points )
@@ -32,14 +34,11 @@ func undo():
 func attribute_upgraded():
 	set_draft_points( draft_points - 1 )
 
-func attribute_downgraded():
-	set_draft_points( draft_points + 1 )
-
 func set_draft_points(points: int):
 	draft_points = points
 	emit_correct_signal()
 	update_points_label()
-	disable_confirm_if_no_action_taken()
+	disable_confirm_and_undo_if_no_action_taken()
 
 func emit_correct_signal():
 	if (draft_points == 0):
@@ -51,9 +50,10 @@ func update_points_label():
 	points_label.text = "Available attribute points: "
 	points_label.text += str( draft_points )
 
-func disable_confirm_if_no_action_taken():
-	var action_taken := draft_points != character.available_attribute_points
-	confirm_button.disabled = not action_taken
+func disable_confirm_and_undo_if_no_action_taken():
+	var no_action_taken := draft_points == character.available_attribute_points
+	confirm_button.disabled = no_action_taken
+	undo_button.disabled = no_action_taken
 
 func spawn_entries_for_attributes():
 	for attribute in StatTypes.new().attributes():

--- a/Scripts/UI/Skill/AttributesUpgrader.gd
+++ b/Scripts/UI/Skill/AttributesUpgrader.gd
@@ -18,16 +18,16 @@ func initialize(_character_changed: Signal):
 
 func store_stats(character: PlayerCombatant):
 	stats = character.stats
-	reset_draft_and_minimum_stats()
+	reset_draft_stats()
 
 func confirm():
 	for attribute in attributes:
 		stats[attribute].set_base_value( draft_stats[attribute] )
-	reset_draft_and_minimum_stats()
+	reset_draft_stats()
 	emit_signal( "stats_confirmed" )
 
 func undo():
-	reset_draft_and_minimum_stats()
+	reset_draft_stats()
 	emit_signal( "stats_undone" )
 
 func attribute_upgrade(attribute: StatTypes.stat_types):
@@ -41,7 +41,7 @@ func class_upgrade(amount: Dictionary):
 	emit_signal( "class_upgraded" )
 	emit_signal( "stats_changed", draft_stats )
 
-func reset_draft_and_minimum_stats():
+func reset_draft_stats():
 	for attribute in attributes:
 		draft_stats[attribute] = stats[attribute].get_base_value()
 	emit_signal( "stats_changed", draft_stats )

--- a/Scripts/UI/Skill/AttributesUpgrader.gd
+++ b/Scripts/UI/Skill/AttributesUpgrader.gd
@@ -14,20 +14,25 @@ func initialize(_character_changed: Signal):
 
 func store_stats(character: PlayerCombatant):
 	stats = character.stats
-	for attribute in attributes:
-		draft_stats[attribute] = stats[attribute].get_base_value()
-	emit_signal( "stats_changed", draft_stats )
+	sync_draft_stats_with_stats()
 
 func confirm():
 	for attribute in attributes:
 		stats[attribute].set_base_value(draft_stats[attribute])
 	emit_signal("stats_confirmed", draft_stats)
 
-func upgrade(attribute: StatTypes.stat_types):
-	set_draft_stat_for_attribute(attribute, draft_stats[attribute] + 1)
+func upgrade(attribute: StatTypes.stat_types, amount: int = 1):
+	set_draft_stat_for_attribute(attribute, draft_stats[attribute] + amount)
 
-func downgrade(attribute: StatTypes.stat_types):	
-	set_draft_stat_for_attribute(attribute, draft_stats[attribute] - 1)
+func downgrade(attribute: StatTypes.stat_types, amount: int = 1):
+	set_draft_stat_for_attribute(attribute, draft_stats[attribute] - amount)
+
+func class_upgrade(amount: Dictionary):
+	for attribute in attributes:
+		upgrade(attribute, amount[attribute])
+
+func undo_class_upgrade():
+	sync_draft_stats_with_stats()
 
 func is_minimum_reached(attribute: StatTypes.stat_types) -> bool:
 	return draft_stats[attribute] <= stats[attribute].get_base_value()
@@ -37,4 +42,9 @@ func get_draft_stats(attribute: StatTypes.stat_types) -> int:
 
 func set_draft_stat_for_attribute(attribute: StatTypes.stat_types, base_value: int):
 	draft_stats[attribute] = base_value
+	emit_signal( "stats_changed", draft_stats )
+
+func sync_draft_stats_with_stats():
+	for attribute in attributes:
+		draft_stats[attribute] = stats[attribute].get_base_value()
 	emit_signal( "stats_changed", draft_stats )

--- a/Scripts/UI/Skill/AttributesUpgrader.gd
+++ b/Scripts/UI/Skill/AttributesUpgrader.gd
@@ -18,7 +18,7 @@ func store_stats(character: PlayerCombatant):
 
 func confirm():
 	for attribute in attributes:
-		stats[attribute].set_base_value(draft_stats[attribute])
+		stats[attribute].set_base_value( draft_stats[attribute] )
 	reset_draft_and_minimum_stats()
 
 func attribute_upgrade(attribute: StatTypes.stat_types):

--- a/Scripts/UI/Skill/AttributesUpgrader.gd
+++ b/Scripts/UI/Skill/AttributesUpgrader.gd
@@ -1,0 +1,40 @@
+## Interface for spending attribute points and skill points
+class_name AttributesUpgrader
+extends Node
+
+signal stats_changed(new_stats: Dictionary)
+signal stats_confirmed(new_stats: Dictionary)
+
+var stats: Dictionary = {} # { attribute: stat }
+var draft_stats: Dictionary = {} # { attribute: base_value }
+var attributes := StatTypes.new().attributes()
+
+func initialize(_character_changed: Signal):
+	_character_changed.connect( store_stats )
+
+func store_stats(character: PlayerCombatant):
+	stats = character.stats
+	for attribute in attributes:
+		draft_stats[attribute] = stats[attribute].get_base_value()
+	emit_signal( "stats_changed", draft_stats )
+
+func confirm():
+	for attribute in attributes:
+		stats[attribute].set_base_value(draft_stats[attribute])
+	emit_signal("stats_confirmed", draft_stats)
+
+func upgrade(attribute: StatTypes.stat_types):
+	set_draft_stat_for_attribute(attribute, draft_stats[attribute] + 1)
+
+func downgrade(attribute: StatTypes.stat_types):	
+	set_draft_stat_for_attribute(attribute, draft_stats[attribute] - 1)
+
+func is_minimum_reached(attribute: StatTypes.stat_types) -> bool:
+	return draft_stats[attribute] <= stats[attribute].get_base_value()
+
+func get_draft_stats(attribute: StatTypes.stat_types) -> int:
+	return draft_stats[attribute]
+
+func set_draft_stat_for_attribute(attribute: StatTypes.stat_types, base_value: int):
+	draft_stats[attribute] = base_value
+	emit_signal( "stats_changed", draft_stats )

--- a/Scripts/UI/Skill/AttributesUpgrader.gd
+++ b/Scripts/UI/Skill/AttributesUpgrader.gd
@@ -11,7 +11,6 @@ signal stats_changed(new_stats: Dictionary)
 
 var stats: Dictionary = {}
 var draft_stats: Dictionary = {} 
-var minimum_for_attribute_downgrade: Dictionary = {}
 var attributes := StatTypes.new().attributes()
 
 func initialize(_character_changed: Signal):
@@ -39,16 +38,13 @@ func attribute_upgrade(attribute: StatTypes.stat_types):
 func class_upgrade(amount: Dictionary):
 	for attribute in attributes:
 		draft_stats[attribute] += amount[attribute]
-		# We just did a class upgrade, so don't allow attribute downgrade to revert this.
-		minimum_for_attribute_downgrade[attribute] = draft_stats[attribute]
 	emit_signal( "class_upgraded" )
 	emit_signal( "stats_changed", draft_stats )
-
-func get_draft_stats(attribute: StatTypes.stat_types) -> int:
-	return draft_stats[attribute]
 
 func reset_draft_and_minimum_stats():
 	for attribute in attributes:
 		draft_stats[attribute] = stats[attribute].get_base_value()
-		minimum_for_attribute_downgrade[attribute] = stats[attribute].get_base_value()
 	emit_signal( "stats_changed", draft_stats )
+
+func get_draft_stats(attribute: StatTypes.stat_types) -> int:
+	return draft_stats[attribute]

--- a/Scripts/UI/Skill/AttributesUpgrader.gd
+++ b/Scripts/UI/Skill/AttributesUpgrader.gd
@@ -2,6 +2,11 @@
 class_name AttributesUpgrader
 extends Node
 
+signal attribute_upgraded
+signal class_upgraded
+
+signal stats_confirmed
+signal stats_undone
 signal stats_changed(new_stats: Dictionary)
 
 var stats: Dictionary = {}
@@ -20,13 +25,15 @@ func confirm():
 	for attribute in attributes:
 		stats[attribute].set_base_value( draft_stats[attribute] )
 	reset_draft_and_minimum_stats()
+	emit_signal( "stats_confirmed" )
+
+func undo():
+	reset_draft_and_minimum_stats()
+	emit_signal( "stats_undone" )
 
 func attribute_upgrade(attribute: StatTypes.stat_types):
 	draft_stats[attribute] += 1
-	emit_signal( "stats_changed", draft_stats )
-
-func attribute_downgrade(attribute: StatTypes.stat_types):
-	draft_stats[attribute] -= 1
+	emit_signal( "attribute_upgraded" )
 	emit_signal( "stats_changed", draft_stats )
 
 func class_upgrade(amount: Dictionary):
@@ -34,13 +41,8 @@ func class_upgrade(amount: Dictionary):
 		draft_stats[attribute] += amount[attribute]
 		# We just did a class upgrade, so don't allow attribute downgrade to revert this.
 		minimum_for_attribute_downgrade[attribute] = draft_stats[attribute]
+	emit_signal( "class_upgraded" )
 	emit_signal( "stats_changed", draft_stats )
-
-func undo_class_upgrade():
-	reset_draft_and_minimum_stats()
-
-func can_do_attribute_downgrade(attribute: StatTypes.stat_types) -> bool:
-	return draft_stats[attribute] > minimum_for_attribute_downgrade[attribute]
 
 func get_draft_stats(attribute: StatTypes.stat_types) -> int:
 	return draft_stats[attribute]

--- a/Scripts/UI/Skill/ClassUpgradeMenu.gd
+++ b/Scripts/UI/Skill/ClassUpgradeMenu.gd
@@ -1,0 +1,37 @@
+class_name ClassUpgradeMenu extends Node
+
+@export var info_container: VBoxContainer
+@export var upgrade_button: Button
+
+var info_labels:= {}
+var class_name_label: Label
+
+var stat_types := StatTypes.new()
+var character: PlayerCombatant
+var character_changed: Signal
+
+func initialize(_character_changed: Signal):
+	character_changed = _character_changed
+	character_changed.connect( update_and_render )
+	spawn_labels_for_attributes()
+	
+func update_and_render(_character: PlayerCombatant):
+	character = _character
+	update_info_labels_text()
+
+func update_info_labels_text():
+	class_name_label.text = "Class: " + str(character.pc_class.localization_name).to_upper()
+	for attribute in stat_types.attributes():
+		info_labels[attribute].text = "> " + stat_types.stat_types_to_string[attribute]
+		info_labels[attribute].text += " on upgrade: "
+		info_labels[attribute].text += str(character.get_attributes_increase()[attribute])
+	
+func spawn_labels_for_attributes():
+	class_name_label = Label.new()
+	info_container.add_child( class_name_label )
+	for attribute in stat_types.attributes():
+		var label := Label.new()
+		info_labels[attribute] = label
+		info_container.add_child( label )
+		
+	

--- a/Scripts/UI/Skill/ClassUpgradeMenu.gd
+++ b/Scripts/UI/Skill/ClassUpgradeMenu.gd
@@ -2,6 +2,7 @@ class_name ClassUpgradeMenu extends Node
 
 @export var info_container: VBoxContainer
 @export var upgrade_button: Button
+@export var upgrader: AttributesUpgrader
 
 signal class_upgraded
 
@@ -34,10 +35,11 @@ func enable_upgrade():
 	upgrade_button.disabled = false
 
 func upgrade():
-	for attribute in stat_types.attributes():
-		var stat := character.stats[attribute] as Stat
-		stat.raise_base_value_by( character.get_attributes_increase()[attribute] )
+	upgrader.class_upgrade(character.get_attributes_increase())
 	emit_signal("class_upgraded")
+
+func undo():
+	upgrader.undo_class_upgrade()
 
 func update_info_labels_text():
 	class_name_label.text = "Class: " + str(character.pc_class.localization_name).to_upper()

--- a/Scripts/UI/Skill/ClassUpgradeMenu.gd
+++ b/Scripts/UI/Skill/ClassUpgradeMenu.gd
@@ -11,14 +11,12 @@ var class_name_label: Label
 
 var stat_types := StatTypes.new()
 var character: PlayerCombatant
-var character_changed: Signal
 
 func initialize(
 	_character_changed: Signal,
 	_points_depleted_signal: Signal, _points_available_signal: Signal):
 
-	character_changed = _character_changed
-	character_changed.connect( update_and_render )
+	_character_changed.connect( update_and_render )
 	_points_depleted_signal.connect( disable_upgrade )
 	_points_available_signal.connect( enable_upgrade )
 	upgrade_button.button_down.connect( upgrade )
@@ -36,13 +34,6 @@ func enable_upgrade():
 
 func upgrade():
 	upgrader.class_upgrade( character.get_attributes_increase() )
-	emit_signal( "class_upgraded" )
-
-func confirm():
-	upgrader.confirm()
-
-func undo():
-	upgrader.undo_class_upgrade()
 
 func update_info_labels():
 	update_class_name_label()

--- a/Scripts/UI/Skill/ClassUpgradeMenu.gd
+++ b/Scripts/UI/Skill/ClassUpgradeMenu.gd
@@ -26,7 +26,7 @@ func initialize(
 	
 func update_and_render(_character: PlayerCombatant):
 	character = _character
-	update_info_labels_text()
+	update_info_labels()
 
 func disable_upgrade():
 	upgrade_button.disabled = true
@@ -35,8 +35,8 @@ func enable_upgrade():
 	upgrade_button.disabled = false
 
 func upgrade():
-	upgrader.class_upgrade(character.get_attributes_increase())
-	emit_signal("class_upgraded")
+	upgrader.class_upgrade( character.get_attributes_increase() )
+	emit_signal( "class_upgraded" )
 
 func confirm():
 	upgrader.confirm()
@@ -44,13 +44,17 @@ func confirm():
 func undo():
 	upgrader.undo_class_upgrade()
 
-func update_info_labels_text():
-	class_name_label.text = "Class: " + str(character.pc_class.localization_name).to_upper()
+func update_info_labels():
+	update_class_name_label()
 	for attribute in stat_types.attributes():
 		info_labels[attribute].text = "> " + stat_types.stat_types_to_string[attribute]
 		info_labels[attribute].text += " on upgrade: "
-		info_labels[attribute].text += str(character.get_attributes_increase()[attribute])
-	
+		info_labels[attribute].text += str( character.get_attributes_increase()[attribute] )
+
+func update_class_name_label():
+	class_name_label.text = "Class: "
+	class_name_label.text += str( character.pc_class.localization_name ).to_upper()
+
 func spawn_labels_for_attributes():
 	class_name_label = Label.new()
 	info_container.add_child( class_name_label )

--- a/Scripts/UI/Skill/ClassUpgradeMenu.gd
+++ b/Scripts/UI/Skill/ClassUpgradeMenu.gd
@@ -38,6 +38,9 @@ func upgrade():
 	upgrader.class_upgrade(character.get_attributes_increase())
 	emit_signal("class_upgraded")
 
+func confirm():
+	upgrader.confirm()
+
 func undo():
 	upgrader.undo_class_upgrade()
 

--- a/Scripts/UI/Skill/ClassUpgradeMenu.gd
+++ b/Scripts/UI/Skill/ClassUpgradeMenu.gd
@@ -3,6 +3,8 @@ class_name ClassUpgradeMenu extends Node
 @export var info_container: VBoxContainer
 @export var upgrade_button: Button
 
+signal class_upgraded
+
 var info_labels:= {}
 var class_name_label: Label
 
@@ -10,14 +12,32 @@ var stat_types := StatTypes.new()
 var character: PlayerCombatant
 var character_changed: Signal
 
-func initialize(_character_changed: Signal):
+func initialize(
+	_character_changed: Signal,
+	_points_depleted_signal: Signal, _points_available_signal: Signal):
+
 	character_changed = _character_changed
 	character_changed.connect( update_and_render )
+	_points_depleted_signal.connect( disable_upgrade )
+	_points_available_signal.connect( enable_upgrade )
+	upgrade_button.button_down.connect( upgrade )
 	spawn_labels_for_attributes()
 	
 func update_and_render(_character: PlayerCombatant):
 	character = _character
 	update_info_labels_text()
+
+func disable_upgrade():
+	upgrade_button.disabled = true
+
+func enable_upgrade():
+	upgrade_button.disabled = false
+
+func upgrade():
+	for attribute in stat_types.attributes():
+		var stat := character.stats[attribute] as Stat
+		stat.raise_base_value_by( character.get_attributes_increase()[attribute] )
+	emit_signal("class_upgraded")
 
 func update_info_labels_text():
 	class_name_label.text = "Class: " + str(character.pc_class.localization_name).to_upper()

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -8,6 +8,7 @@ class_name SkillMenu extends Control
 @export var canvas: CanvasLayer
 @export var skills_tree_renderer: SkillsTreeRenderer
 @export var attributes_menu: AttributesMenu
+@export var class_upgrade_menu: ClassUpgradeMenu
 
 signal skill_points_depleted
 signal character_changed(character: PlayerCombatant)
@@ -24,7 +25,8 @@ func _ready():
 	confirm_button.button_down.connect( confirm_points )
 	undo_skill_points_button.button_down.connect( undo_points )
 	skills_tree_renderer.initialize( on_skill_upgraded, skill_points_depleted )
-	attributes_menu.initialize(character_changed)
+	attributes_menu.initialize( character_changed )
+	class_upgrade_menu.initialize( character_changed )
 
 func add_tabs_per_character():
 	tab_bar.clear_tabs()

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -9,6 +9,7 @@ class_name SkillMenu extends Control
 @export var skills_tree_renderer: SkillsTreeRenderer
 @export var attributes_menu: AttributesMenu
 @export var class_upgrade_menu: ClassUpgradeMenu
+@export var attributes_upgrader: AttributesUpgrader
 
 signal skill_points_depleted
 signal skill_points_available
@@ -26,6 +27,7 @@ func _ready():
 	confirm_button.button_down.connect( confirm_points )
 	undo_skill_points_button.button_down.connect( undo_points )
 	skills_tree_renderer.initialize( on_skill_upgraded, skill_points_depleted )
+	attributes_upgrader.initialize( character_changed )
 	attributes_menu.initialize( character_changed )
 	class_upgrade_menu.initialize( 
 		character_changed, skill_points_depleted, skill_points_available )

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -26,12 +26,12 @@ func _ready():
 	exit_button.button_down.connect( canvas.hide )
 	confirm_button.button_down.connect( confirm_points )
 	undo_skill_points_button.button_down.connect( undo_points )
-	skills_tree_renderer.initialize( on_skill_upgraded, skill_points_depleted )
+	skills_tree_renderer.initialize( deduct_one_point, skill_points_depleted )
 	attributes_upgrader.initialize( character_changed )
 	attributes_menu.initialize( character_changed )
 	class_upgrade_menu.initialize( 
 		character_changed, skill_points_depleted, skill_points_available )
-	class_upgrade_menu.class_upgraded.connect( on_class_upgraded )
+	class_upgrade_menu.class_upgraded.connect( deduct_one_point )
 
 func add_tabs_per_character():
 	tab_bar.clear_tabs()
@@ -56,15 +56,11 @@ func confirm_points():
 	get_tree().call_group( skills_tree_renderer.skills_group_name, "confirm" )
 
 func undo_points():
-	attributes_menu.refresh()
 	set_draft_skill_points( current_character.available_skill_points )
+	class_upgrade_menu.undo()
 	get_tree().call_group( skills_tree_renderer.skills_group_name, "undo" )
 
-func on_skill_upgraded():
-	set_draft_skill_points( draft_available_skill_points - 1 )
-
-func on_class_upgraded():
-	attributes_menu.refresh()
+func deduct_one_point():
 	set_draft_skill_points( draft_available_skill_points - 1 )
 
 func set_draft_skill_points(new_value: int):

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -54,11 +54,12 @@ func confirm_points():
 	current_character.available_skill_points = draft_available_skill_points
 	set_draft_skill_points( current_character.available_skill_points )
 	get_tree().call_group( skills_tree_renderer.skills_group_name, "confirm" )
+	class_upgrade_menu.confirm()
 
 func undo_points():
 	set_draft_skill_points( current_character.available_skill_points )
-	class_upgrade_menu.undo()
 	get_tree().call_group( skills_tree_renderer.skills_group_name, "undo" )
+	class_upgrade_menu.undo()
 
 func deduct_one_point():
 	set_draft_skill_points( draft_available_skill_points - 1 )

--- a/Scripts/UI/Skill/SkillMenu.gd
+++ b/Scripts/UI/Skill/SkillMenu.gd
@@ -31,7 +31,7 @@ func _ready():
 	attributes_menu.initialize( character_changed )
 	class_upgrade_menu.initialize( 
 		character_changed, skill_points_depleted, skill_points_available )
-	class_upgrade_menu.class_upgraded.connect( deduct_one_point )
+	attributes_upgrader.class_upgraded.connect( deduct_one_point )
 
 func add_tabs_per_character():
 	tab_bar.clear_tabs()
@@ -51,15 +51,21 @@ func render_tab(index: int):
 		set_draft_skill_points( current_character.available_skill_points )
 
 func confirm_points():
+	confirm_skills()
+	attributes_upgrader.confirm()
+
+func confirm_skills():
 	current_character.available_skill_points = draft_available_skill_points
 	set_draft_skill_points( current_character.available_skill_points )
 	get_tree().call_group( skills_tree_renderer.skills_group_name, "confirm" )
-	class_upgrade_menu.confirm()
 
 func undo_points():
+	undo_skills()
+	attributes_upgrader.undo()
+
+func undo_skills():
 	set_draft_skill_points( current_character.available_skill_points )
 	get_tree().call_group( skills_tree_renderer.skills_group_name, "undo" )
-	class_upgrade_menu.undo()
 
 func deduct_one_point():
 	set_draft_skill_points( draft_available_skill_points - 1 )


### PR DESCRIPTION
## Changes
* Fix bug that attribute point upgrades did not increase by 1, but were using `on_increase` values of character's class
* Introduced `ClassUpgradeMenu` and `AttributesUpgrader`
* Use one confirm/undo button for both skills and attribute points 

Responsibilities are:
* `AttributesUpgrader`: upgrade attributes both from spending attribute points and upgrading class levels
* `SkillsMenu`:  manages available skill points; confirm/undo is triggered here, which uses the upgrader to confirm/undo attributes changes.
* `AttributesMenu`: manages available attribute points by using upgrader signals
* `AttributeMenuEntry` and `ClassUpgradeMenu`: update UI elements

![image](https://github.com/EveningComet/Project-Horizon/assets/33893929/6919869d-4cb0-4890-95f3-fccc3e3ddc06)

![Animation](https://github.com/EveningComet/Project-Horizon/assets/33893929/5a7e2050-7336-488c-9336-58eebab13370)
