### PR TITLE
[Status Effects] Add icon on adding/removing status effects

### DIFF
--- a/Game Data/Status Effects/Status Effect Burned.tres
+++ b/Game Data/Status Effects/Status Effect Burned.tres
@@ -1,6 +1,7 @@
-[gd_resource type="Resource" script_class="StatusEffect" load_steps=6 format=3 uid="uid://buul67l7164jj"]
+[gd_resource type="Resource" script_class="StatusEffect" load_steps=7 format=3 uid="uid://buul67l7164jj"]
 
 [ext_resource type="Script" path="res://Scripts/Character/Status Effect/StatusEffect.gd" id="1_7s4dm"]
+[ext_resource type="Texture2D" uid="uid://cpfkjabev02kd" path="res://Imported Assets/UI/Wenrexa UI Kit #4/Icons/Icon18.png" id="1_tbqd7"]
 [ext_resource type="Script" path="res://Scripts/Character/Status Effect/Status Effect Data/StatusEffectOnApplyData.gd" id="1_wu8ok"]
 [ext_resource type="Script" path="res://Scripts/Character/Status Effect/Status Effect Data/StatusEffectOnTurnTickData.gd" id="2_ihqes"]
 
@@ -22,6 +23,7 @@ stat_modifiers = Array[Resource("res://Scripts/Stats/StatModifier.gd")]([])
 script = ExtResource("1_7s4dm")
 localization_name = "Burned"
 localization_description = "The fire got to you, what can I say."
+display_texture = ExtResource("1_tbqd7")
 on_apply = SubResource("Resource_7ttbn")
 on_turn_tick = SubResource("Resource_1dhul")
 duration_in_turns = 2

--- a/Game Data/Status Effects/Status Effect Inspired.tres
+++ b/Game Data/Status Effects/Status Effect Inspired.tres
@@ -1,6 +1,7 @@
-[gd_resource type="Resource" script_class="StatusEffect" load_steps=6 format=3 uid="uid://budclfsmtpc5x"]
+[gd_resource type="Resource" script_class="StatusEffect" load_steps=7 format=3 uid="uid://cbwa3cddmrgx7"]
 
 [ext_resource type="Script" path="res://Scripts/Character/Status Effect/StatusEffect.gd" id="1_ce3bg"]
+[ext_resource type="Texture2D" uid="uid://b2fnwlaebjwee" path="res://Imported Assets/UI/Wenrexa UI Kit #4/Icons/Icon11.png" id="1_easrt"]
 [ext_resource type="Script" path="res://Scripts/Character/Status Effect/Status Effect Data/StatusEffectOnApplyData.gd" id="1_q4yfk"]
 [ext_resource type="Script" path="res://Scripts/Stats/StatModifier.gd" id="2_wt74u"]
 
@@ -21,5 +22,6 @@ stat_modifiers = Array[ExtResource("2_wt74u")]([SubResource("Resource_1h6my")])
 script = ExtResource("1_ce3bg")
 localization_name = "Inspired"
 localization_description = "The sky's the limit for you."
+display_texture = ExtResource("1_easrt")
 on_apply = SubResource("Resource_figji")
 duration_in_turns = 1

--- a/Scenes/UI/Battle/Enemy Battle UI.tscn
+++ b/Scenes/UI/Battle/Enemy Battle UI.tscn
@@ -1,23 +1,35 @@
-[gd_scene load_steps=5 format=3 uid="uid://cjy7rqj2i7mo8"]
+[gd_scene load_steps=4 format=3 uid="uid://cjy7rqj2i7mo8"]
 
 [ext_resource type="Script" path="res://Scripts/UI/Battle/CombatantBattleUI.gd" id="1_bhbwu"]
 [ext_resource type="Texture2D" uid="uid://b2dvigjefvd7u" path="res://Imported Assets/Aekashics Librarium Sprites/Cyber Ogre.png" id="1_fx5ve"]
 [ext_resource type="PackedScene" uid="uid://hjy64lja4jo5" path="res://Scenes/UI/Battle/Damage Text Displayer.tscn" id="3_aphws"]
 
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_45agv"]
-
-[node name="Enemy Battle UI" type="PanelContainer" node_paths=PackedStringArray("portrait")]
+[node name="Enemy Battle UI" type="Control" node_paths=PackedStringArray("portrait", "status_effects_container")]
+custom_minimum_size = Vector2(300, 300)
+layout_mode = 3
+anchors_preset = 0
 offset_right = 20.0
 offset_bottom = 20.0
 mouse_filter = 1
-theme_override_styles/panel = SubResource("StyleBoxEmpty_45agv")
 script = ExtResource("1_bhbwu")
-portrait = NodePath("Enemy Portrait")
+portrait = NodePath("PortraitContainer/Enemy Portrait")
 damage_text_template = ExtResource("3_aphws")
+status_effects_container = NodePath("StatusEffectsContainer")
 
-[node name="Enemy Portrait" type="TextureRect" parent="."]
+[node name="PortraitContainer" type="MarginContainer" parent="."]
+layout_mode = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="Enemy Portrait" type="TextureRect" parent="PortraitContainer"]
 custom_minimum_size = Vector2(300, 300)
 layout_mode = 2
 texture = ExtResource("1_fx5ve")
 expand_mode = 1
 stretch_mode = 5
+
+[node name="StatusEffectsContainer" type="HBoxContainer" parent="."]
+layout_mode = 0
+offset_right = 300.0
+offset_bottom = 58.0
+alignment = 2

--- a/Scenes/UI/Battle/Player Character Battle UI.tscn
+++ b/Scenes/UI/Battle/Player Character Battle UI.tscn
@@ -103,8 +103,8 @@ text = "SP: 99/99"
 [node name="StatusEffectsContainer" type="HBoxContainer" parent="."]
 custom_minimum_size = Vector2(225, 0)
 offset_left = 112.0
-offset_top = 85.0
+offset_top = 81.0
 offset_right = 337.0
-offset_bottom = 143.0
+offset_bottom = 139.0
 scale = Vector2(0.5, 0.5)
 alignment = 2

--- a/Scenes/UI/Battle/Player Character Battle UI.tscn
+++ b/Scenes/UI/Battle/Player Character Battle UI.tscn
@@ -18,58 +18,68 @@ border_color = Color(1, 1, 1, 1)
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_7r0ni"]
 
-[node name="Player Character Battle UI" type="PanelContainer" node_paths=PackedStringArray("portrait_displayer", "border", "hp_display_text", "sp_display_text")]
+[node name="Player Battle UI" type="Control" node_paths=PackedStringArray("portrait_displayer", "portrait", "border", "hp_display_text", "sp_display_text", "status_effects_container")]
+custom_minimum_size = Vector2(225, 100)
+layout_mode = 3
+anchors_preset = 0
+offset_right = 225.0
+offset_bottom = 100.0
+script = ExtResource("1_k7vii")
+portrait_displayer = NodePath("Player Character Battle UI/MarginContainer/HBoxContainer/Portrait Displayer")
+portrait = NodePath("Player Character Battle UI/MarginContainer/HBoxContainer/Portrait Displayer/MarginContainer/Icon")
+border = NodePath("Player Character Battle UI/BorderPanel")
+is_player_controlled = true
+hp_display_text = NodePath("Player Character Battle UI/MarginContainer/HBoxContainer/Vitals/VBoxContainer/HP Display")
+sp_display_text = NodePath("Player Character Battle UI/MarginContainer/HBoxContainer/Vitals/VBoxContainer/SP Display")
+status_effects_container = NodePath("StatusEffectsContainer")
+
+[node name="Player Character Battle UI" type="PanelContainer" parent="."]
 custom_minimum_size = Vector2(225, 100)
 offset_right = 200.0
 offset_bottom = 100.0
 theme_override_styles/panel = SubResource("StyleBoxTexture_v5rcx")
-script = ExtResource("1_k7vii")
-portrait_displayer = NodePath("MarginContainer/HBoxContainer/Portrait Displayer")
-border = NodePath("BorderPanel")
-hp_display_text = NodePath("MarginContainer/HBoxContainer/Vitals/VBoxContainer/HP Display")
-sp_display_text = NodePath("MarginContainer/HBoxContainer/Vitals/VBoxContainer/SP Display")
 
-[node name="BorderPanel" type="Panel" parent="."]
+[node name="BorderPanel" type="Panel" parent="Player Character Battle UI"]
 visible = false
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_kvnyo")
 
-[node name="MarginContainer" type="MarginContainer" parent="."]
+[node name="MarginContainer" type="MarginContainer" parent="Player Character Battle UI"]
 layout_mode = 2
 theme_override_constants/margin_left = 1
 theme_override_constants/margin_top = 1
 theme_override_constants/margin_right = 1
 theme_override_constants/margin_bottom = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Player Character Battle UI/MarginContainer"]
 layout_mode = 2
 
-[node name="Portrait Displayer" type="PanelContainer" parent="MarginContainer/HBoxContainer" node_paths=PackedStringArray("display_icon")]
+[node name="Portrait Displayer" type="PanelContainer" parent="Player Character Battle UI/MarginContainer/HBoxContainer" node_paths=PackedStringArray("display_icon")]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_styles/panel = SubResource("StyleBoxEmpty_7r0ni")
 script = ExtResource("3_bpgkw")
 display_icon = NodePath("MarginContainer/Icon")
 
-[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/HBoxContainer/Portrait Displayer"]
+[node name="MarginContainer" type="MarginContainer" parent="Player Character Battle UI/MarginContainer/HBoxContainer/Portrait Displayer"]
 layout_mode = 2
 theme_override_constants/margin_left = 5
 theme_override_constants/margin_top = 5
 theme_override_constants/margin_right = 5
 theme_override_constants/margin_bottom = 5
 
-[node name="Icon" type="TextureRect" parent="MarginContainer/HBoxContainer/Portrait Displayer/MarginContainer"]
+[node name="Icon" type="TextureRect" parent="Player Character Battle UI/MarginContainer/HBoxContainer/Portrait Displayer/MarginContainer"]
 custom_minimum_size = Vector2(64, 64)
 layout_mode = 2
 texture = ExtResource("4_xf6o6")
 expand_mode = 1
 stretch_mode = 5
 
-[node name="Vitals" type="Control" parent="MarginContainer/HBoxContainer"]
+[node name="Vitals" type="Control" parent="Player Character Battle UI/MarginContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer/Vitals"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Player Character Battle UI/MarginContainer/HBoxContainer/Vitals"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -78,14 +88,23 @@ grow_horizontal = 2
 grow_vertical = 2
 alignment = 1
 
-[node name="HP Display" type="RichTextLabel" parent="MarginContainer/HBoxContainer/Vitals/VBoxContainer"]
+[node name="HP Display" type="RichTextLabel" parent="Player Character Battle UI/MarginContainer/HBoxContainer/Vitals/VBoxContainer"]
 custom_minimum_size = Vector2(10, 30)
 layout_mode = 2
 theme_override_font_sizes/normal_font_size = 18
 text = "HP: 99/99"
 
-[node name="SP Display" type="RichTextLabel" parent="MarginContainer/HBoxContainer/Vitals/VBoxContainer"]
+[node name="SP Display" type="RichTextLabel" parent="Player Character Battle UI/MarginContainer/HBoxContainer/Vitals/VBoxContainer"]
 custom_minimum_size = Vector2(10, 30)
 layout_mode = 2
 theme_override_font_sizes/normal_font_size = 18
 text = "SP: 99/99"
+
+[node name="StatusEffectsContainer" type="HBoxContainer" parent="."]
+custom_minimum_size = Vector2(225, 0)
+offset_left = 112.0
+offset_top = 85.0
+offset_right = 337.0
+offset_bottom = 143.0
+scale = Vector2(0.5, 0.5)
+alignment = 2

--- a/Scripts/Battle/Combatant.gd
+++ b/Scripts/Battle/Combatant.gd
@@ -3,6 +3,8 @@ class_name Combatant extends Node
 
 ## Called when a stat on this character has been changed.
 signal stat_changed( combatant: Combatant )
+signal status_effect_added( combatant: Combatant, effect: StatusEffect )
+signal status_effect_removed( combatant: Combatant, effect: StatusEffect )
 
 # Scaling values
 const VITALITY_HP_SCALER:              int = 3

--- a/Scripts/Character/Status Effect/StatusEffect.gd
+++ b/Scripts/Character/Status Effect/StatusEffect.gd
@@ -4,7 +4,7 @@ class_name StatusEffect extends Resource
 ## The name for this status effect.
 @export var localization_name:                  String = "New Status Effect"
 @export_multiline var localization_description: String = "Status effect description."
-
+@export var display_texture: Texture2D
 @export var on_apply: StatusEffectOnApplyData
 @export var on_turn_tick: StatusEffectOnTurnTickData
 @export var on_expire: StatusEffectOnExpireData

--- a/Scripts/Character/Status Effect/StatusEffectHolder.gd
+++ b/Scripts/Character/Status Effect/StatusEffectHolder.gd
@@ -15,6 +15,7 @@ func add_status_effect(status_to_add: StatusEffect) -> void:
 	if (not statuses.has(status_to_add)):
 		statuses[status_to_add] = status_to_add.duration_in_turns
 		status_to_add.trigger_on_apply(monitored_combatant)
+		monitored_combatant.status_effect_added.emit(monitored_combatant, status_to_add)
 		print(monitored_combatant, ": added status effect ", status_to_add.localization_name, " for ", status_to_add.duration_in_turns, " turns")
 
 func apply_status_effects() -> void:
@@ -30,4 +31,5 @@ func apply_status_effects() -> void:
 func remove_status_effect(status_to_remove: StatusEffect) -> void:
 	status_to_remove.trigger_on_expire(monitored_combatant)
 	statuses.erase(status_to_remove)
+	monitored_combatant.status_effect_removed.emit(monitored_combatant, status_to_remove)
 	print(monitored_combatant, ": removed status effect ", status_to_remove.localization_name)

--- a/Scripts/UI/Battle/CombatantBattleUI.gd
+++ b/Scripts/UI/Battle/CombatantBattleUI.gd
@@ -1,6 +1,6 @@
 ## Displays the vitals for a character. Doubles as a middleman for accessing
 ## a character's data.
-class_name CombatantBattleUI extends PanelContainer
+class_name CombatantBattleUI extends Control
 
 @export var portrait_displayer: PortraitDisplayer
 
@@ -16,12 +16,15 @@ class_name CombatantBattleUI extends PanelContainer
 
 @export var hp_display_text: RichTextLabel
 @export var sp_display_text: RichTextLabel
+@export var status_effects_container: Container
 
 ## The combatant currently being monitored.
 var combatant: Combatant
 
 ## Stores a copy of the character's vitals for showing the differences.
 var vital_stats: Dictionary = {} 
+
+var status_effects: Dictionary = {}
 
 ## Set the new combatant to monitor and update the displays if needed.
 func set_combatant(new_combatant: Combatant, is_player_owned: bool) -> void:
@@ -30,6 +33,8 @@ func set_combatant(new_combatant: Combatant, is_player_owned: bool) -> void:
 	vital_stats[StatTypes.stat_types.CurrentHP] = combatant.get_current_hp()
 	vital_stats[StatTypes.stat_types.CurrentSP] = combatant.get_current_sp()
 	combatant.stat_changed.connect( on_stat_changed )
+	combatant.status_effect_added.connect( on_status_effect_added )
+	combatant.status_effect_removed.connect( on_status_effect_removed )
 	if is_player_controlled == true:
 		portrait_displayer.display_icon.set_texture( 
 			combatant.portrait_data.small_portrait
@@ -77,6 +82,33 @@ func on_stat_changed(monitored: Combatant) -> void:
 		
 		if monitored.stats[StatTypes.stat_types.CurrentHP] <= 0:
 			queue_free()
+
+
+func on_status_effect_added(monitored: Combatant, effect: StatusEffect) -> void:
+	if effect.display_texture == null:
+		return
+	if is_player_controlled == true:
+		# TODO: add for player
+		pass
+	else:
+		var new_icon := TextureRect.new()
+		new_icon.texture = effect.display_texture
+		new_icon.tooltip_text = effect.localization_name + "\n" + effect.localization_description
+		status_effects[effect] = new_icon
+		status_effects_container.add_child(status_effects[effect])
+
+
+func on_status_effect_removed(monitored: Combatant, effect: StatusEffect) -> void:
+	if not effect in status_effects: 
+		return
+	if is_player_controlled == true:
+		# TODO: add for player
+		pass
+	else:
+		status_effects_container.remove_child(status_effects[effect])
+		status_effects[effect].queue_free()
+		status_effects.erase(effect)
+		
 
 func get_combatant() -> Combatant:
 	return combatant

--- a/Scripts/UI/Battle/CombatantBattleUI.gd
+++ b/Scripts/UI/Battle/CombatantBattleUI.gd
@@ -87,27 +87,19 @@ func on_stat_changed(monitored: Combatant) -> void:
 func on_status_effect_added(monitored: Combatant, effect: StatusEffect) -> void:
 	if effect.display_texture == null:
 		return
-	if is_player_controlled == true:
-		# TODO: add for player
-		pass
-	else:
-		var new_icon := TextureRect.new()
-		new_icon.texture = effect.display_texture
-		new_icon.tooltip_text = effect.localization_name + "\n" + effect.localization_description
-		status_effects[effect] = new_icon
-		status_effects_container.add_child(status_effects[effect])
+	var new_icon := TextureRect.new()
+	new_icon.texture = effect.display_texture
+	new_icon.tooltip_text = effect.localization_name + "\n" + effect.localization_description
+	status_effects[effect] = new_icon
+	status_effects_container.add_child(status_effects[effect])
 
 
 func on_status_effect_removed(monitored: Combatant, effect: StatusEffect) -> void:
 	if not effect in status_effects: 
 		return
-	if is_player_controlled == true:
-		# TODO: add for player
-		pass
-	else:
-		status_effects_container.remove_child(status_effects[effect])
-		status_effects[effect].queue_free()
-		status_effects.erase(effect)
+	status_effects_container.remove_child(status_effects[effect])
+	status_effects[effect].queue_free()
+	status_effects.erase(effect)
 		
 
 func get_combatant() -> Combatant:


### PR DESCRIPTION
## Changes
* Added `StatusEffectContainer` to Player and Enemy UI
* Show the current status effect on adding/removing
* The tooltip of status effect in the player UI is not consistently showing, most likely because icon is too small, so there we may want to redesign the layout - skipped in this PR for now.

![Animation](https://github.com/EveningComet/Project-Horizon/assets/33893929/26605750-8df2-4aeb-9991-4ea7c732444b)
