### PR TITLE
[Status Effects] Make contagious effects possible

### DIFF
--- a/Game Data/Status Effects/Status Effect Burned.tres
+++ b/Game Data/Status Effects/Status Effect Burned.tres
@@ -13,7 +13,6 @@ stat_modifiers = Array[Resource("res://Scripts/Stats/StatModifier.gd")]([])
 
 [sub_resource type="Resource" id="Resource_1dhul"]
 script = ExtResource("2_ihqes")
-perception_increase = 0
 increase_ratio_per_turn = 0.5
 base_damage = 3
 damage_type = 1
@@ -24,6 +23,8 @@ script = ExtResource("1_7s4dm")
 localization_name = "Burned"
 localization_description = "The fire got to you, what can I say."
 display_texture = ExtResource("1_tbqd7")
+is_contagious = false
+incubation_time = 0
 on_apply = SubResource("Resource_7ttbn")
 on_turn_tick = SubResource("Resource_1dhul")
 duration_in_turns = 2

--- a/Game Data/Status Effects/Status Effect Inspired.tres
+++ b/Game Data/Status Effects/Status Effect Inspired.tres
@@ -23,5 +23,6 @@ script = ExtResource("1_ce3bg")
 localization_name = "Inspired"
 localization_description = "The sky's the limit for you."
 display_texture = ExtResource("1_easrt")
+is_contagious = false
 on_apply = SubResource("Resource_figji")
 duration_in_turns = 1

--- a/Game Data/Status Effects/Status Effect Plagued.tres
+++ b/Game Data/Status Effects/Status Effect Plagued.tres
@@ -1,0 +1,31 @@
+[gd_resource type="Resource" script_class="StatusEffect" load_steps=7 format=3 uid="uid://boll3cqsa20nb"]
+
+[ext_resource type="Texture2D" uid="uid://deped7j5m2rvm" path="res://Imported Assets/UI/Wenrexa UI Kit #4/Icons/Icon13.png" id="1_o55p8"]
+[ext_resource type="Script" path="res://Scripts/Character/Status Effect/StatusEffect.gd" id="1_v1m0u"]
+[ext_resource type="Script" path="res://Scripts/Character/Status Effect/Status Effect Data/StatusEffectOnApplyData.gd" id="2_isqjg"]
+[ext_resource type="Script" path="res://Scripts/Character/Status Effect/Status Effect Data/StatusEffectOnTurnTickData.gd" id="3_44xq6"]
+
+[sub_resource type="Resource" id="Resource_lxqdp"]
+script = ExtResource("2_isqjg")
+base_damage = 1
+damage_type = 2
+stat_modifiers = Array[Resource("res://Scripts/Stats/StatModifier.gd")]([])
+
+[sub_resource type="Resource" id="Resource_kqobo"]
+script = ExtResource("3_44xq6")
+increase_ratio_per_turn = 0.25
+base_damage = 3
+damage_type = 1
+stat_modifiers = Array[Resource("res://Scripts/Stats/StatModifier.gd")]([])
+
+[resource]
+script = ExtResource("1_v1m0u")
+localization_name = "Plagued"
+localization_description = "You've gone viral."
+display_texture = ExtResource("1_o55p8")
+is_contagious = true
+chance_of_spreading = 0.5
+incubation_time = 2
+on_apply = SubResource("Resource_lxqdp")
+on_turn_tick = SubResource("Resource_kqobo")
+duration_in_turns = 3

--- a/Scripts/Battle/Battle Manager/Battle Manager States/BattleStart.gd
+++ b/Scripts/Battle/Battle Manager/Battle Manager States/BattleStart.gd
@@ -31,6 +31,7 @@ func setup_battle() -> void:
 func spawn_player_characters() -> void:
 	# Add the player's party to the battle
 	for player_character: PlayerCombatant in PlayerPartyController.party_members:
+		player_character.add_to_group( my_state_machine.PLAYER_GROUP_NAME )
 		player_character.reparent( my_state_machine.spawned_combatants_node )
 		
 		# Make the state machine keep track of the character
@@ -42,6 +43,7 @@ func spawn_player_characters() -> void:
 func spawn_enemies() -> void:
 	for enemy_data in MissionController.current_mission.enemies:
 		var enemy_combatant = make_enemy( enemy_data )
+		enemy_combatant.add_to_group( my_state_machine.ENEMY_GROUP_NAME )
 		my_state_machine.add_combatant( enemy_combatant )
 		my_state_machine.spawned_combatants_node.add_child( enemy_combatant )
 		EventBus.combatant_spawned_in_battle.emit( enemy_combatant )

--- a/Scripts/Battle/Battle Manager/BattleManager.gd
+++ b/Scripts/Battle/Battle Manager/BattleManager.gd
@@ -13,6 +13,12 @@ class_name BattleManager extends StateMachine
 ## Houses the spawned characters.
 @export var spawned_combatants_node: Node
 
+## The group name of nodes that are EnemyCombatant
+const ENEMY_GROUP_NAME := "EnemyCombatants"
+
+## The group name of nodes that are PlayerCombatant
+const PLAYER_GROUP_NAME := "PlayerCombatants"
+
 ## The current actions that will be executed.
 var current_turn_actions: Array[StoredAction] = []
 

--- a/Scripts/Character/Status Effect/Status Effect Data/StatusEffectOnTurnTickData.gd
+++ b/Scripts/Character/Status Effect/Status Effect Data/StatusEffectOnTurnTickData.gd
@@ -1,8 +1,6 @@
 ## Contains information to apply status effects
 class_name StatusEffectOnTurnTickData extends StatusEffectData
 
-@export var perception_increase: int = 0
-
 @export_range(0.0, 1.0, .05) var increase_ratio_per_turn: float = 0
 
 func damage_increase_per_turn() -> int:

--- a/Scripts/Character/Status Effect/StatusEffect.gd
+++ b/Scripts/Character/Status Effect/StatusEffect.gd
@@ -5,6 +5,9 @@ class_name StatusEffect extends Resource
 @export var localization_name:                  String = "New Status Effect"
 @export_multiline var localization_description: String = "Status effect description."
 @export var display_texture: Texture2D
+@export var is_contagious: bool
+@export_range(0.0, 1.0, .05) var chance_of_spreading: float
+@export var incubation_time: int
 @export var on_apply: StatusEffectOnApplyData
 @export var on_turn_tick: StatusEffectOnTurnTickData
 @export var on_expire: StatusEffectOnExpireData

--- a/Scripts/Character/Status Effect/StatusEffectHolder.gd
+++ b/Scripts/Character/Status Effect/StatusEffectHolder.gd
@@ -7,16 +7,31 @@ var monitored_combatant: Combatant
 ## The current statuses and how many turns they have left.
 var statuses: Dictionary = {}
 
+## The queued statuses and how many turns before their activation
+var queued_statuses: Dictionary = {}
+
 
 func initialize(combatant: Combatant) -> void:
 	monitored_combatant = combatant
-	
+
+
+func get_contagious_status_effects() -> Array:
+	return statuses.keys().filter(func(status): return status.is_contagious)
+
+
+func queue_status_effect(status_to_queue: StatusEffect) -> void:
+	if not queued_statuses.has(status_to_queue) and not statuses.has(status_to_queue):
+		queued_statuses[status_to_queue] = status_to_queue.incubation_time
+		print(monitored_combatant, ": queued status effect ", status_to_queue.localization_name, ", incubation time: ", queued_statuses[status_to_queue], " turns")
+
+
 func add_status_effect(status_to_add: StatusEffect) -> void:
 	if (not statuses.has(status_to_add)):
 		statuses[status_to_add] = status_to_add.duration_in_turns
 		status_to_add.trigger_on_apply(monitored_combatant)
 		monitored_combatant.status_effect_added.emit(monitored_combatant, status_to_add)
 		print(monitored_combatant, ": added status effect ", status_to_add.localization_name, " for ", status_to_add.duration_in_turns, " turns")
+
 
 func apply_status_effects() -> void:
 	for status in statuses:
@@ -27,6 +42,16 @@ func apply_status_effects() -> void:
 			status.trigger_on_turn_tick(monitored_combatant, turns_elapsed)
 			statuses[status] -= 1
 			print(monitored_combatant, ": ticked status effect ", status.localization_name, ", turns left: ", statuses[status])
+	tick_queued_effects()
+
+
+func tick_queued_effects() -> void:
+	for status in queued_statuses:
+		queued_statuses[status] -= 1
+		if queued_statuses[status] == 0:
+			add_status_effect(status)
+			queued_statuses.erase(status)
+
 
 func remove_status_effect(status_to_remove: StatusEffect) -> void:
 	status_to_remove.trigger_on_expire(monitored_combatant)


### PR DESCRIPTION
## Changes
* Removed unused `perception_increase`
* Added `is_contagious`, `incubation_time`, and `chance_of_spreading` to status effects
* A contagious status effect will randomly select a member of the combatant's party, and based on the chance of spreading, infects them. The infected party member gets the status effect after `incubation_time` (in turns).

(Misusing the `Stun` skill to test, did not commit that.)
![Animation](https://github.com/EveningComet/Project-Horizon/assets/33893929/3ce3f8a0-c19e-4c72-a8d1-5c97fc29fe44)
